### PR TITLE
Revert structs to only include basic inputs

### DIFF
--- a/wdl/structs.wdl
+++ b/wdl/structs.wdl
@@ -8,23 +8,12 @@ struct Sample {
 	Array[File]+ fastq_R2s
 	Array[File] fastq_I1s
 	Array[File] fastq_I2s
-
-	File? visium_brightfield_image
-	String? visium_slide_serial_number
-	String? visium_capture_area
-
-	File? geomx_lab_annotation_xlsx
 }
 
 struct Project {
 	String team_id
 	String dataset_id
 	Array[Sample] samples
-
-	File? project_sample_metadata_csv
-	File? project_condition_metadata_csv
-
-	File? geomx_config_ini
 
 	Boolean run_project_cohort_analysis
 


### PR DESCRIPTION
For each pipeline, create own "Sample" and "Project" structs because 1) it's getting big and 2) optional fields are confusing if it's actually required.