### PR TITLE
File metadata transfer

### DIFF
--- a/util/transfer_qc_metadata_to_raw_bucket
+++ b/util/transfer_qc_metadata_to_raw_bucket
@@ -39,12 +39,6 @@ FILE_METADATA_FILES_TO_SYNC = [
     "artifacts.csv",
     "raw_files.csv",
     "curated_files.csv",
-    "v1.0.0", # cohort datasets have versioned subdirs
-    "v2.0.0",
-    "v3.0.0",
-    "v3.0.1",
-    "v3.0.2",
-    "v4.0.0",
 ]
 
 
@@ -76,20 +70,13 @@ def main(args):
         for file_name in FILE_METADATA_FILES_TO_SYNC:
             file_path = file_metadata_dir / file_name
             if file_path.exists():
-                logging.info(f"Transferring file: {file_name}")
-                # Gsync for dirs, gcopy for files
-                if file_path.is_dir():
-                    gsync(source_path=file_path, 
-                          destination_path=f"{file_metadata_bucket}/{file_name}", 
-                          dry_run=dry_run)
+                if dry_run:
+                    logging.info(f"Would copy {file_path} to {file_metadata_bucket}/{file_name}")
                 else:
-                    if dry_run:
-                        logging.info(f"Would copy {file_path} to {file_metadata_bucket}/{file_name}")
-                    else:
-                        gcopy(source_path=file_path, 
-                              destination_path=f"{file_metadata_bucket}/{file_name}",
-                              recursive=False)
- 
+                    logging.info(f"Transferring file: {file_name}")
+                    gcopy(source_path=str(file_path), 
+                          destination_path=f"{file_metadata_bucket}/{file_name}",
+                          recursive=False)
             else:
                 logging.warning(f"File not found, skipping: {file_name}")
     else:


### PR DESCRIPTION
## Description
Only transfer selected file_metadata files. Add dry_run argument to gcopy as gcloud cp does not have this
## Dependencies (Issues/PRs)

[ClickUp Issue](https://app.clickup.com/t/9014209604/BIOS-1822)

[GitHub PR](https://github.com/ASAP-CRN/wf-common/pull/60)

## Type of Change

- [ ] Bug fix
- [x] New feature
- [ ] Documentation

## Task Checklist

- [x] Documentation updated

