### PR TITLE
Data upload via GCP console

### DIFF
--- a/util/common.py
+++ b/util/common.py
@@ -78,47 +78,29 @@ def run_command(command):
 			raise
 
 
-def check_admin_binding(type, bucket_name):
+def check_admin_binding(bucket_name):
 	team_name = get_team_name(bucket_name)
 	role_admin = "roles/storage.admin"
-	if type == "gg":
-		team_gg = "asap-team-" + team_name + "@dnastack.com"
-		member = f"group:{team_gg}"
-		policy_json = run_command([
-			"gcloud",
-			"storage",
-			"buckets",
-			"get-iam-policy",
-			bucket_name,
-			"--format=json"
-		])
-		policy = json.loads(policy_json)
-		has_admin_binding = any(
-			binding["role"] == role_admin and member in binding.get("members", [])
-			for binding in policy.get("bindings", [])
-		)
-		return member, role_admin, has_admin_binding
-	if type == "sa":
-		team_sa = "raw-admin-" + team_name + "@dnastack-asap-parkinsons.iam.gserviceaccount.com"
-		member = f"serviceAccount:{team_sa}"
-		policy_json = run_command([
-			"gcloud",
-			"storage",
-			"buckets",
-			"get-iam-policy",
-			bucket_name,
-			"--format=json"
-		])
-		policy = json.loads(policy_json)
-		has_admin_binding = any(
-			binding["role"] == role_admin and member in binding.get("members", [])
-			for binding in policy.get("bindings", [])
-		)
-		return member, role_admin, has_admin_binding
+	team_gg = "asap-team-" + team_name + "@dnastack.com"
+	member = f"group:{team_gg}"
+	policy_json = run_command([
+		"gcloud",
+		"storage",
+		"buckets",
+		"get-iam-policy",
+		bucket_name,
+		"--format=json"
+	])
+	policy = json.loads(policy_json)
+	has_admin_binding = any(
+		binding["role"] == role_admin and member in binding.get("members", [])
+		for binding in policy.get("bindings", [])
+	)
+	return member, role_admin, has_admin_binding
 
 
 def change_gg_storage_admin_to_read_write(bucket_name):
-	member, role_admin, has_admin_binding = check_admin_binding("gg", bucket_name)
+	member, role_admin, has_admin_binding = check_admin_binding(bucket_name)
 	if has_admin_binding:
 		print(f"[INFO] Removing Storage Admin access and granting Storage Object Creator and Viewer to CRN Teams for [{bucket_name}] on Google Group")
 		run_command([
@@ -150,41 +132,6 @@ def change_gg_storage_admin_to_read_write(bucket_name):
 		])
 	else:
 		print(f"[INFO] Storage Object Creator and Viewer already granted to CRN Teams' permissions for [{bucket_name}] on Google Group")
-
-
-def change_sa_storage_admin_to_read_write(bucket_name):
-	member, role_admin, has_admin_binding = check_admin_binding("sa", bucket_name)
-	if has_admin_binding:
-		print(f"[INFO] Removing Storage Admin access and granting Storage Object Creator and Viewer to CRN Teams for [{bucket_name}] on Service Account")
-		run_command([
-			"gcloud",
-			"storage",
-			"buckets",
-			"remove-iam-policy-binding",
-			bucket_name,
-			f"--member={member}",
-			f"--role={role_admin}"
-		])
-		run_command([
-			"gcloud",
-			"storage",
-			"buckets",
-			"add-iam-policy-binding",
-			bucket_name,
-			f"--member={member}",
-			"--role=roles/storage.objectViewer"
-		])
-		run_command([
-			"gcloud",
-			"storage",
-			"buckets",
-			"add-iam-policy-binding",
-			bucket_name,
-			f"--member={member}",
-			"--role=roles/storage.objectCreator"
-		])
-	else:
-		print(f"[INFO] Storage Object Creator and Viewer already granted to CRN Teams' permissions for [{bucket_name}] on Service Account")
 
 
 ##########################################################################

--- a/util/promote_raw_data
+++ b/util/promote_raw_data
@@ -18,7 +18,6 @@ from common import (
 	gsync_del,
 	remove_internal_qc_label,
 	change_gg_storage_admin_to_read_write,
-	change_sa_storage_admin_to_read_write,
 	add_verily_read_access,
 )
 
@@ -112,7 +111,6 @@ def main(args):
 				add_verily_read_access(raw_bucket)
 				# Remove Storage Admin access from CRN Teams and grant Storage Object Creator and Viewer to released raw buckets
 				change_gg_storage_admin_to_read_write(raw_bucket)
-				change_sa_storage_admin_to_read_write(raw_bucket)
 
 			# Remove old metadata that's in PROD metadata/release/
 			if "metadata" in dirs:

--- a/util/promote_staging_data
+++ b/util/promote_staging_data
@@ -20,7 +20,6 @@ from common import (
 	gsync,
 	remove_internal_qc_label,
 	change_gg_storage_admin_to_read_write,
-	change_sa_storage_admin_to_read_write,
 	add_verily_read_access,
 )
 from markdown_generator import generate_markdown_report
@@ -200,7 +199,6 @@ def main(args):
 					add_verily_read_access(raw_bucket)
 					logging.info(f"Removing Storage Admin access and granting Storage Object Creator and Viewer to CRN Teams for [{raw_bucket}]")
 					change_gg_storage_admin_to_read_write(raw_bucket)
-					change_sa_storage_admin_to_read_write(raw_bucket)
 
 			logging.info(f"Promoting [{dataset_id}] data to production")
 			logging.info(f"\tStaging bucket:\t\t[{staging_uat_bucket}]")


### PR DESCRIPTION
## Description

Add an option for CRN Teams to upload their data via the console. This also involves changing the current process and removing the need for SAs and Secrets. The `bucket_structure.sh` script has been re-purposed to the [`create_asap_bucket.sh`](https://github.com/DNAstack/dnastack-workflow-service/blob/asap/parkinsons/projects/asap/parkinsons-2024/scripts/create_asap_bucket.sh) script.

## Dependencies (Issues/PRs)

[BIOS-1846](https://app.clickup.com/t/9014209604/BIOS-1846)

## Type of Change

- [ ] Bug fix
- [x] New feature
- [x] Documentation

## Task Checklist

- [x] Documentation updated

