### PR TITLE
update with link to dataset-metadata readme

### DIFF
--- a/util/README.md
+++ b/util/README.md
@@ -25,6 +25,8 @@
 
 This section describes the workflow for processing contributor submissions, from initial upload through QC and back to the raw bucket.
 
+See documentation in the [asap-crn-cloud-dataset-metadata](https://github.com/ASAP-CRN/asap-crn-cloud-dataset-metadata/blob/main/README.md) repo for more granular information on the steps pertaining to releasing a contributed dataset.
+
 ## Workflow Steps
 
 ### 1. Validate Bucket Structure
@@ -95,6 +97,7 @@ Build Publisher collection cards text and figures using:
 ```
 
 **release-resources outputs:**
+
 ```
 release-resources/
 └─ {release_version}/
@@ -124,7 +127,6 @@ Syncs the local release-resources directory (including all QC'd subdirectories) 
 - `release_stats/` final svg files
 
 **Note:** Use `-p` flag to execute (defaults to dry-run for safety).
-
 
 ---
 


### PR DESCRIPTION
## Description

Update README to point to asap-crn-cloud-dataset-metadata README


- Added link to the other repo's README at the top of the Contributor Data Workflow section (section 3. Perform QC Locally already links to the repo itself).
- [This link](https://github.com/ASAP-CRN/asap-crn-cloud-dataset-metadata/blob/feature/update-readme/README.md) has the updated dataset-metadata README, which I haven't merged yet in case you wanted one last look. I will assume it is good to go if this PR is approved.
- I only added the Metadata Files section from this README (with a bit of additional context), as the other details talk more about the overall structure of the buckets, which I deemed as less relevant for the dataset-metadata README.

## Dependencies (Issues/PRs)

[ClickUp Issue](click-up url)

[GitHub PR](https://github.com/ASAP-CRN/asap-crn-cloud-dataset-metadata/pull/81)

## Type of Change

- [ ] Bug fix
- [ ] New feature
- [x] Documentation

## Task Checklist

- [x] Documentation updated
 