### PR TITLE
Feature/update crn stats

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -15,4 +15,5 @@
 ## Task Checklist
 
 - [ ] Documentation updated
+- [ ] Human reviewed any code produced or modified by AI
 

--- a/util/README.md
+++ b/util/README.md
@@ -12,8 +12,8 @@
 | [`promote_staging_data`](./promote_staging_data) | Promote staging data to production data buckets and apply the appropriate permissions. | Ability to run data integrity tests when trying to promote data from staging (i.e., DEV/UAT) to production buckets (i.e., CURATED). This script is only run for Minor and Major releases. It also applies the appropriate permissions to the buckets (e.g., adding Verily's ASAP Cloud Readers to released raw buckets) and removes the `internal-qc-data` label from the released raw buckets. The buckets/datasets are detected based on the workflow name provided and the workflow/pipeline version that's used to store current curated outputs in raw workflow_execution bucket. This dict, `unembargoed_dev_buckets_and_workflow_version_outputs`, is in `common.py` | `./promote_staging_data -w pmdbs_sc_rnaseq --release-version v4.0.0 --collection-version v3.1.0` |
 | [`markdown_generator.py`](./markdown_generator.py) | Functions that generate a Markdown report. | This script is used in the [`promote_staging_data`](./promote_staging_data) script to generate a Markdown report that contains data integrity results when trying to promote data from staging (i.e., DEV/UAT) to production buckets (i.e., CURATED). | NA |
 | [`crn_cloud_collection_summary`](./crn_cloud_collection_summary) | Track the ASAP raw/curated buckets, size, sample breakdown, and subject breakdown in the CRN Cloud. | See [CRN Cloud Statistics](#crn-cloud-statistics) below for more details. | `./crn_cloud_collection_summary` |
-| [`generate_dataset_summary_table`](./generate_dataset_summary_table) | Generate pivot tables of unique subject/sample counts and subject diagnosis counts by organism × tissue type × assay from CRN Cloud summary outputs. | Run after `crn_cloud_collection_summary` to produce summary tables for reporting. Reads from the Google Releases Sheet via `get_releases_df()`. | `python3 generate_dataset_summary_table crn_cloud_collection_summary.<date>.tsv subject_dataset_membership.<date>.tsv sample_dataset_membership.<date>.tsv subject_diagnosis_membership.<date>.tsv` |
 | [`internal_qc_dataset_collection_summary`](./internal_qc_dataset_collection_summary) | Track datasets in internal QC by getting their ASAP raw buckets, size, sample, and subject breakdown in GCP. | See [CRN Cloud Statistics](#crn-cloud-statistics) below for more details. | `./internal_qc_dataset_collection_summary` |
+| [`generate_dataset_summary_table`](./generate_dataset_summary_table) | Generate pivot tables of unique subject/sample counts and subject diagnosis counts by organism × tissue type × assay from CRN Cloud or internal QC summary outputs. | Run after `crn_cloud_collection_summary` or `internal_qc_dataset_collection_summary` to produce summary tables for reporting. Auto-detects input source from the filename and prefixes outputs accordingly. Reads dataset metadata from the Google Releases Sheet via `get_releases_df()` when available; falls back to slug-name classification otherwise. | `python3 generate_dataset_summary_table <prefix>.<date>.tsv <prefix>.subject_dataset_membership.<date>.tsv <prefix>.sample_dataset_membership.<date>.tsv <prefix>.subject_diagnosis_membership.<date>.tsv` |
 | [`transfer_release_resources_to_raw_bucket.py`](./transfer_release_resources_to_raw_bucket.py) | Sync local release-resources config/, release_stats/ and publisher_cards/ to dataset ASAP raw buckets. | After producing Publisher card text and summary figures, this script syncs locally stored files (presumably living at asap-crn-cloud-dataset-metadata/) into each dataset gs:// raw bucket. If any later changes are made to the release-resources, this script will need to be re-run to ensure that the raw bucket contains the most up to date copies. | `./transfer_release_resources_to_raw_bucket.py -i /path/to/release_<release_version>.json -p` |
 | [`clean_wdl_raw_buckets`](./clean_wdl_raw_buckets) | Clean up script for GCP raw bucket workflow execution timestamp cohort analysis and downstream folders. | Removes outdated timestamp folder contents across all raw buckets in the cohort analysis and downstream folders while preserving versions. | `./clean_wdl_raw_buckets -p` |
 
@@ -275,10 +275,10 @@ Queries the [CRN Cloud](https://cloud.parkinsonsroadmap.org) via the DNAstack CL
 
 **Output:**
 - `crn_cloud_collection_summary.<date>.tsv`
-- `subject_dataset_membership.<date>.tsv` — one row per subject-dataset pair (excludes cohorts)
-- `sample_dataset_membership.<date>.tsv` — one row per sample-dataset pair (excludes cohorts)
-- `brain_donor_dataset_membership.<date>.tsv` — one row per brain donor-dataset pair (excludes cohorts)
-- `subject_diagnosis_membership.<date>.tsv` — one row per subject-diagnosis-dataset pair, human datasets only (CLINPATH → SUBJECT → SAMPLE `condition_id` priority order)
+- `crn_cloud_collection_summary.subject_dataset_membership.<date>.tsv` — one row per subject-dataset pair (excludes cohorts)
+- `crn_cloud_collection_summary.sample_dataset_membership.<date>.tsv` — one row per sample-dataset pair (excludes cohorts)
+- `crn_cloud_collection_summary.brain_donor_dataset_membership.<date>.tsv` — one row per brain donor-dataset pair (excludes cohorts)
+- `crn_cloud_collection_summary.subject_diagnosis_membership.<date>.tsv` — one row per subject-diagnosis-dataset pair, human datasets only (CLINPATH → SUBJECT → SAMPLE `condition_id` priority order)
 
 | Column | Description |
 |--------|-------------|
@@ -323,53 +323,28 @@ OPTIONS
 
 ---
 
----
-
-### `generate_dataset_summary_table`
-
-Generates pivot tables of unique subject/sample counts and subject diagnosis counts by organism × tissue type × assay. Reads dataset metadata (organism, sample source, assay) from the Google Releases Sheet via `get_releases_df()`, and joins with the membership files output by `crn_cloud_collection_summary` to deduplicate subjects and samples globally across datasets.
-
-**Input files** (all outputs of `crn_cloud_collection_summary`):
-- `crn_cloud_collection_summary.<date>.tsv`
-- `subject_dataset_membership.<date>.tsv`
-- `sample_dataset_membership.<date>.tsv`
-- `subject_diagnosis_membership.<date>.tsv`
-
-**Output:**
-- `dataset_summary_table.<date>.tsv` — pivot table of unique subjects/samples by organism × tissue type × assay
-- `dataset_summary_table.<date>.xlsx` — same table as Excel with merged organism headers (if `openpyxl` installed)
-- `subject_diagnosis_table.<date>.tsv` — pivot table of unique subject diagnosis counts, human datasets only
-
-**Usage:**
-```bash
-python3 generate_dataset_summary_table \
-    crn_cloud_collection_summary.<date>.tsv \
-    subject_dataset_membership.<date>.tsv \
-    sample_dataset_membership.<date>.tsv \
-    subject_diagnosis_membership.<date>.tsv
-```
-
-**Notes:**
-- Cohort slugs are excluded from all tables
-- Tissue type classification uses `sample_source` and `organism` from the Releases Sheet; datasets with non-standard values are flagged as warnings
-- `prod-team-scherzer-pmdbs-genetics` is hard-coded as Human / Brain tissue / Genetics due to a non-standard `assay` value in the sheet
-- Requires `gspread` credentials at `~/.config/gspread/credentials.json` (see [gspread setup](#set-up-for-pulling-data-from-live-google-spreadsheets-using-gspread))
-
----
-
 ### `internal_qc_dataset_collection_summary`
 
-Scans GCP directly for `asap-raw-team-*` buckets labelled `internal-qc-data` and reports sample/subject counts by reading `SAMPLE.csv` from each bucket's metadata path. Intended for tracking datasets currently in internal QC that are not yet published to the CRN Cloud.
+Scans GCP directly for `asap-raw-team-*` buckets labelled `internal-qc-data` and reports sample, subject, brain sample, brain donor, and diagnosis breakdowns by reading `SAMPLE.csv`, `PMDBS.csv`, and `CLINPATH.csv` from each bucket's metadata path. Intended for tracking datasets currently in internal QC that are not yet published to the CRN Cloud. Output column names mirror those of `crn_cloud_collection_summary` so the same `generate_dataset_summary_table` pivot script works on either source.
 
-**Output:** `internal_qc_dataset_collection_summary.<date>.tsv`
+**Output:**
+- `internal_qc_dataset_collection_summary.<date>.tsv` - sample breakdown and bucket size if selected
+- `internal_qc_dataset_collection_summary.subject_dataset_membership.<date>.tsv` — one row per subject-dataset pair
+- `internal_qc_dataset_collection_summary.sample_dataset_membership.<date>.tsv` — one row per sample-dataset pair
+- `internal_qc_dataset_collection_summary.brain_donor_dataset_membership.<date>.tsv` — one row per brain donor-dataset pair
+- `internal_qc_dataset_collection_summary.subject_diagnosis_membership.<date>.tsv` — one row per subject-diagnosis-dataset pair, human datasets only
 
 | Column | Description |
 |--------|-------------|
+| `publisher_slug` | Dataset slug name, synthesized from bucket name as `prod-team-...` |
 | `team` | Team name parsed from bucket name |
 | `gcp_raw_bucket` | GCS raw bucket URI |
 | `gcp_raw_bucket_size` | Raw bucket size in bytes |
 | `sample_count` | Distinct `sample_id` count from `SAMPLE.csv` |
 | `subject_count` | Distinct `subject_id` count from `SAMPLE.csv` |
+| `n_brain_samples` | Brain sample count from `PMDBS.csv` if present, else count of rows in `SAMPLE.csv` where `tissue ~ /brain/i` |
+| `n_brain_donors` | Distinct donors in `CLINPATH.csv` that also appear in `PMDBS.csv` (or `SAMPLE.region_level_1` if PMDBS not present) |
+| `n_subjects_<diagnosis>` | Per-diagnosis subject counts pulled from `CLINPATH.csv` (priority order: `primary_diagnosis` → `last_diagnosis` → `path_autopsy_dx_main` → `path_autopsy_second_dx`; any column with numeric-only values is skipped) |
 
 **Usage:**
 ```bash
@@ -382,9 +357,48 @@ OPTIONS
 ```
 
 **Notes:**
-- Requires `gcloud` authenticated with access to `asap-raw-team-*` buckets
-- Looks for `SAMPLE.csv` first at `metadata/release/SAMPLE.csv`, then searches the full `metadata/` prefix as a fallback
+- Requires `gcloud` authenticated with access to `asap-raw-team-*` buckets, plus `python3` for CSV parsing
+- Looks for `SAMPLE.csv`, `PMDBS.csv`, and `CLINPATH.csv` first at `metadata/release/<name>.csv`, then searches the full `metadata/` prefix as a fallback
 - Datasets with no `SAMPLE.csv` found will report `NA` for sample and subject counts
+- All `gcloud storage cat` output is piped through a CSV normalizer that flattens multi-line quoted fields before parsing, so awk-based downstream processing is safe
+- Membership file column names match the CRN script's output so `generate_dataset_summary_table` accepts either source
+- The `internal-qc-data` label is checked on each bucket and the script skips buckets not currently labelled as such (so released buckets fall out of internal-QC reporting once promoted)
+
+---
+
+### `generate_dataset_summary_table`
+
+Generates pivot tables of unique subject/sample counts and subject diagnosis counts by organism × tissue type × assay. Reads dataset metadata (organism, sample source, assay) from the Google Releases Sheet via `get_releases_df()` when available, falling back to slug-name pattern matching for datasets not in the Sheet. Joins with the membership files output by `crn_cloud_collection_summary` or `internal_qc_dataset_collection_summary` to deduplicate subjects and samples globally across datasets.
+
+**Input files** (outputs of `crn_cloud_collection_summary` or `internal_qc_dataset_collection_summary` used as <prefix> here):
+- `<prefix>.<date>.tsv`
+- `<prefix>.subject_dataset_membership.<date>.tsv`
+- `<prefix>.sample_dataset_membership.<date>.tsv`
+- `<prefix>.subject_diagnosis_membership.<date>.tsv`
+
+**Output**:
+- `dataset_summary_table.<timestamp>.tsv` — table of unique subjects/samples by organism × tissue type × assay
+- `subject_diagnosis_table.<timestamp>.tsv` — table of unique subject diagnosis counts, human datasets only
+
+**Usage:**
+```bash
+python3 generate_dataset_summary_table \
+    <prefix>.<date>.tsv \
+    <prefix>.subject_dataset_membership.<date>.tsv \
+    <prefix>.sample_dataset_membership.<date>.tsv \
+    <prefix>.subject_diagnosis_membership.<date>.tsv
+```
+
+**Notes:**
+- Cohort slugs are excluded from all tables
+- Output filenames are prefixed based on the input filename: `crn_cloud_*` → `crn_*`, `internal_qc_*` → `internal_qc_*`, anything else → no prefix
+- Tissue type classification uses `sample_source` and `organism` from the Releases Sheet when available; datasets not present in the Releases Sheet (typical for internal QC) fall back to slug-name pattern matching
+- Datasets with non-standard `sample_source` / `organism` values are flagged as warnings
+- `prod-team-scherzer-pmdbs-genetics` is hard-coded as Human / Brain tissue / Genetics due to a non-standard `assay` value in the sheet
+- Mass-spec data type patterns are kept mutually exclusive: `ms-p` → Proteomics, `ms-mb` → Metabolomics, `ms-l` → Lipidomics (the slug classifier requires the pattern to appear with a separator, so `ms-p` won't accidentally match `ms-mb`)
+- `mefs` in a slug is classified as Mouse / Embryonic fibroblast (the bucket-name classifier; the Releases Sheet path uses the Sheet's `organism` field directly)
+- The Releases Sheet fetch is wrapped in try/except — if `gspread` credentials are missing or the fetch fails, the script logs a warning and proceeds with slug-name classification only
+- Requires `gspread` credentials at `~/.config/gspread/credentials.json` (see [gspread setup](#set-up-for-pulling-data-from-live-google-spreadsheets-using-gspread)); optional for slug-only classification
 
 ---
 
@@ -396,11 +410,15 @@ Both scripts print a breakdown to stdout after writing the TSV, including counts
 | Group | Matched bucket patterns |
 |-------|------------------------|
 | sc/sn RNAseq | `sc-rnaseq`, `sn-rnaseq` |
+| sc/sn ATACseq | `sc-atacseq`, `sn-atacseq` |
+| sc/sn Multiome | `multimodal`, `multiome`, `multiomics` |
 | bulk RNAseq | `bulk-rnaseq` |
-| spatial | `spatial` |
+| spatial transcriptomics | `spatial` |
 | proteomics | `ms-p` |
-| parsebio | `parsebio` |
-| multimodal | `multimodal`, `multiome`, `multiomics` |
+| metabolomics | `ms-mb` |
+| lipidomics | `ms-l` |
+| genetics | `genetics` |
+| wgs | `wgs` |
 | metagenomics | `metagenome` |
 | other | anything else |
 
@@ -416,9 +434,11 @@ Buckets that fall into the `other` category are listed explicitly in the output 
 
 ## Dependencies
 
+- [`gcloud` CLI](https://cloud.google.com/sdk/gcloud) — required for `crn_cloud_collection_summary` and `internal_qc_dataset_collection_summary`
 - [`dnastack` CLI](https://docs.dnastack.com/docs/cli-overview) — required for `crn_cloud_collection_summary` only
-- [`gcloud` CLI](https://cloud.google.com/sdk/gcloud) — required for both scripts
 - `jq` — required for `crn_cloud_collection_summary`
+- `python3` (≥ 3.8) — required for `internal_qc_dataset_collection_summary` and `generate_dataset_summary_table`
+- `pandas`, `gspread` — required for `generate_dataset_summary_table`; `gspread` is optional and only enables Releases-sheet-based classification
 
 # Helpful resources
 

--- a/util/crn_cloud_collection_summary
+++ b/util/crn_cloud_collection_summary
@@ -213,13 +213,13 @@ if [[ -n "${PREVIOUS_CRN_SUMMARY_TSV:-}" ]]; then
     echo "Appending to existing file: $output_file"
 else
     output_file="crn_cloud_collection_summary.$date_str.tsv"
-    subject_membership_file="subject_dataset_membership.$date_str.tsv"
-    brain_donor_membership_file="brain_donor_dataset_membership.$date_str.tsv"
+    subject_membership_file="crn_cloud_collection_summary.subject_dataset_membership.$date_str.tsv"
+    brain_donor_membership_file="crn_cloud_collection_summary.brain_donor_dataset_membership.$date_str.tsv"
     echo -e "subject_id\tpublisher_slug" > "$subject_membership_file"
     echo -e "asap_subject_id\tpublisher_slug" > "$brain_donor_membership_file"
-    subject_diagnosis_membership_file="subject_diagnosis_membership.$date_str.tsv"
+    subject_diagnosis_membership_file="crn_cloud_collection_summary.subject_diagnosis_membership.$date_str.tsv"
     echo -e "asap_subject_id\tprimary_diagnosis\tpublisher_slug" > "$subject_diagnosis_membership_file"
-    sample_membership_file="sample_dataset_membership.$date_str.tsv"
+    sample_membership_file="crn_cloud_collection_summary.sample_dataset_membership.$date_str.tsv"
     echo -e "asap_sample_id\tpublisher_slug" > "$sample_membership_file"
     echo -e "publisher_slug\tgcp_raw_bucket\tgcp_raw_bucket_size\tgcp_curated_bucket\tgcp_curated_bucket_size\tteam_name\tn_samples\tn_subjects\tn_brain_samples\tn_brain_regions\tn_brain_donors\tn_subjects_healthy_control\tn_subjects_idiopathic_pd\tn_subjects_alzheimers_disease\tn_subjects_frontotemporal_dementia\tn_subjects_corticobasal_syndrome\tn_subjects_dementia_with_lewy_bodies\tn_subjects_dopa_responsive_dystonia\tn_subjects_essential_tremor\tn_subjects_hemiparkinson_hemiatrophy_syndrome\tn_subjects_juvenile_autosomal_recessive_parkinsonism\tn_subjects_motor_neuron_disease_with_parkinsonism\tn_subjects_multiple_system_atrophy\tn_subjects_neuroleptic_induced_parkinsonism\tn_subjects_normal_pressure_hydrocephalus\tn_subjects_progressive_supranuclear_palsy\tn_subjects_psychogenic_parkinsonism\tn_subjects_vascular_parkinsonism\tn_subjects_no_pd_nor_other_neurological_disorder\tn_subjects_spinocerebellar_ataxia_sca\tn_subjects_prodromal_non_motor_pd\tn_subjects_prodromal_motor_pd\tn_subjects_crohns_disease\tn_subjects_crohns_disease_remission\tn_subjects_other_neurological_disorder\tn_subjects_other_non_neurological_disease_or_condition\tcondition_counts" > "$output_file"
 fi
@@ -236,15 +236,18 @@ _SAMPLE_IDS_FILE=$(mktemp /tmp/sample_ids.XXXXXX)
 trap 'rm -f "$_DIAG_LABELS_FILE" "$_HUMAN_IDS_FILE" "$_MOUSE_IDS_FILE" "$_CELL_IDS_FILE" "$_BRAIN_DONOR_IDS_FILE" "$_SAMPLE_IDS_FILE"' EXIT
 
 while IFS= read -r slug; do
+    # Skip blank lines (and the trailing newline-only "row" that read produces)
+    [[ -z "$slug" ]] && continue
+
     underscored_slug="${slug//-/_}"
 
     # Split slug into parts
     IFS='-' read -r -a parts <<< "$slug"
 
-    if [[ "${parts[0]}" == "prod" && "${parts[1]}" == "team" ]]; then
-        team_name="${parts[2]}"
-    elif [[ "${parts[0]}" == "prod" ]]; then
-        team_name="${parts[1]}"
+    if [[ "${parts[0]:-}" == "prod" && "${parts[1]:-}" == "team" ]]; then
+        team_name="${parts[2]:-}"
+    elif [[ "${parts[0]:-}" == "prod" ]]; then
+        team_name="${parts[1]:-}"
     else
         echo "Cannot parse team name for slug: $slug" >&2
         continue
@@ -266,7 +269,7 @@ while IFS= read -r slug; do
     # Cohort slugs have their own gs://asap-raw-cohort-* buckets — derive directly
     # from the slug rather than reading gcp_uri from the DATA table (which points
     # to individual team buckets, not the cohort bucket).
-    if [[ "${parts[1]}" == "cohort" ]]; then
+    if [[ "${parts[1]:-}" == "cohort" ]]; then
         gcp_raw_bucket=$(echo "$slug" | sed 's;prod-;gs://asap-raw-;g')
         if ! gcloud storage buckets describe "$gcp_raw_bucket" >/dev/null 2>&1; then
             echo "[WARNING] Cohort bucket does NOT exist: [$gcp_raw_bucket]; skipping" >&2
@@ -325,40 +328,74 @@ while IFS= read -r slug; do
     fi
 
     # Collect subject IDs for global deduplication.
-    # Try each ID type in order — first match wins for this dataset.
-    # For each type, check the dedicated table first, then SUBJECT as fallback.
-    if [[ "${parts[1]}" != "cohort" ]]; then
+    # Classify origin by bucket name FIRST (because some sample tables use
+    # `asap_subject_id` as a generic column populated with mouse IDs for
+    # mouse studies — column name doesn't reliably indicate organism).
+    # Then try ID columns in an origin-appropriate priority order.
+    if [[ "${parts[1]:-}" != "cohort" ]]; then
+        # Origin from bucket name (mirrors the awk classifier in calculate_breakdown)
+        if [[ "$gcp_raw_bucket" == *human* ]] || [[ "$gcp_raw_bucket" == *pmdbs* ]]; then
+            _bucket_origin="human"
+            _dest_file="$_HUMAN_IDS_FILE"
+            _id_cols=("asap_subject_id")
+            _src_tables=("${team_name}_sample" "${team_name}_subject")
+        elif [[ "$gcp_raw_bucket" == *mouse* ]] || [[ "$gcp_raw_bucket" == *sulzer-fecal-metagenome-fp-spf* ]]; then
+            _bucket_origin="mouse"
+            _dest_file="$_MOUSE_IDS_FILE"
+            # Mouse SAMPLE tables in some teams use asap_subject_id with mouse values;
+            # try asap_mouse_id first (true mouse table) then asap_subject_id (sample table)
+            _id_cols=("asap_mouse_id" "asap_subject_id")
+            _src_tables=("${team_name}_mouse" "${team_name}_sample" "${team_name}_subject")
+        elif [[ "$gcp_raw_bucket" == *cell* ]] || [[ "$gcp_raw_bucket" == *invitro* ]] || [[ "$gcp_raw_bucket" == *ipsc* ]] || [[ "$gcp_raw_bucket" == *mef* ]]; then
+            _bucket_origin="cell"
+            _dest_file="$_CELL_IDS_FILE"
+            _id_cols=("asap_cell_id" "asap_subject_id")
+            _src_tables=("${team_name}_cell" "${team_name}_sample" "${team_name}_subject")
+        else
+            _bucket_origin="other"
+            _dest_file=""
+            _id_cols=()
+            _src_tables=()
+        fi
+
         _collected=false
-        for _id_spec in "asap_subject_id:human:${team_name}_sample:${team_name}_subject" \
-                        "asap_mouse_id:mouse:${team_name}_sample:${team_name}_mouse" \
-                        "asap_cell_id:cell:${team_name}_sample:${team_name}_cell"; do
-            _id_col=$(echo "$_id_spec" | cut -d: -f1)
-            _origin=$(echo  "$_id_spec" | cut -d: -f2)
-            _tables=$(echo  "$_id_spec" | cut -d: -f3-)
-            if [[ "$_id_col" == "asap_subject_id" ]]; then _dest_file="$_HUMAN_IDS_FILE"
-            elif [[ "$_id_col" == "asap_mouse_id" ]]; then _dest_file="$_MOUSE_IDS_FILE"
-            else _dest_file="$_CELL_IDS_FILE"; fi
-            IFS=: read -ra _src_tables <<< "$_tables"
-            for _src_table in "${_src_tables[@]}"; do
-                if ! echo "$collection_tables" | grep -qi "$_src_table"; then continue; fi
-                dnastack collections query -c "$slug" \
-                    "SELECT DISTINCT $_id_col FROM \"collections\".\"$underscored_slug\".\"${_src_table}\"
-                    WHERE $_id_col IS NOT NULL" \
-                    -o csv 2>/dev/null | tail -n +2 | tr -d '\r,"' | grep -v '^$' > /tmp/_ids_tmp.txt 2>/dev/null || true
-                if [[ -s /tmp/_ids_tmp.txt ]]; then
-                    cat /tmp/_ids_tmp.txt >> "$_dest_file"
-                    while IFS= read -r _id; do
-                        printf "%s\t%s\n" "$_id" "$slug" >> "$subject_membership_file"
-                    done < /tmp/_ids_tmp.txt
-                    _collected=true
-                    break 2
-                fi
+        if [[ -n "$_dest_file" ]]; then
+            for _id_col in "${_id_cols[@]}"; do
+                for _src_table in "${_src_tables[@]}"; do
+                    if ! echo "$collection_tables" | grep -qi "$_src_table"; then continue; fi
+                    # Verify the column actually exists in this table before querying
+                    if ! dnastack collections query -c "$slug" \
+                        "SELECT column_name FROM collections.information_schema.columns
+                         WHERE table_schema = '$underscored_slug'
+                           AND table_name = '${_src_table}'
+                           AND column_name = '${_id_col}'
+                         LIMIT 1" \
+                        -o csv 2>/dev/null | tail -n +2 | grep -q "$_id_col"; then
+                        continue
+                    fi
+                    dnastack collections query -c "$slug" \
+                        "SELECT DISTINCT $_id_col FROM \"collections\".\"$underscored_slug\".\"${_src_table}\"
+                        WHERE $_id_col IS NOT NULL" \
+                        -o csv 2>/dev/null | tail -n +2 | tr -d '\r,"' | grep -v '^$' > /tmp/_ids_tmp.txt 2>/dev/null || true
+                    if [[ -s /tmp/_ids_tmp.txt ]]; then
+                        cat /tmp/_ids_tmp.txt >> "$_dest_file"
+                        while IFS= read -r _id; do
+                            printf "%s\t%s\n" "$_id" "$slug" >> "$subject_membership_file"
+                        done < /tmp/_ids_tmp.txt
+                        _collected=true
+                        echo "  Collected $(wc -l < /tmp/_ids_tmp.txt | tr -d '[:space:]') $_bucket_origin IDs from ${_src_table}.${_id_col}"
+                        break 2
+                    fi
+                done
             done
-        done
+            if ! "$_collected"; then
+                echo "  [WARN] No $_bucket_origin IDs collected for $slug"
+            fi
+        fi
     fi
 
     # Collect sample IDs for global deduplication
-    if [[ "${parts[1]}" != "cohort" ]]; then
+    if [[ "${parts[1]:-}" != "cohort" ]]; then
         if echo "$collection_tables" | grep -qi "${team_name}_sample"; then
             dnastack collections query -c "$slug" \
                 "SELECT DISTINCT asap_sample_id FROM \"collections\".\"$underscored_slug\".\"${team_name}_sample\"
@@ -626,10 +663,12 @@ calculate_breakdown() {
             grp["bulk"] += count
         } else if (bucket ~ /spatial/) {
             grp["spatial"] += count
-        } else if (bucket ~ /ms-p/) {
+        } else if (bucket ~ /-ms-p-/ || bucket ~ /-ms-p$/) {
             grp["ms_p"] += count
-        } else if (bucket ~ /parsebio/) {
-            grp["parsebio"] += count
+        } else if (bucket ~ /-ms-mb-/ || bucket ~ /-ms-mb$/) {
+            grp["ms_mb"] += count
+        } else if (bucket ~ /-ms-l-/ || bucket ~ /-ms-l$/) {
+            grp["ms_l"] += count
         } else if (bucket ~ /multimodal/ || bucket ~ /multiome/ || bucket ~ /multiomics/) {
             grp["multiome"] += count
         } else if (bucket ~ /metagenome/) {
@@ -667,7 +706,8 @@ calculate_breakdown() {
         printf "bulk RNAseq:   %d\n", grp["bulk"]
         printf "spatial:       %d\n", grp["spatial"]
         printf "proteomics:    %d\n", grp["ms_p"]
-        printf "parsebio:      %d\n", grp["parsebio"]
+        printf "metabolomics:  %d\n", grp["ms_mb"]
+        printf "lipidomics:    %d\n", grp["ms_l"]
         printf "genetics:      %d\n", grp["genetics"]
         printf "wgs:           %d\n", grp["wgs"]
         printf "metagenomics:  %d\n", grp["metagenomics"]

--- a/util/crn_cloud_collection_summary
+++ b/util/crn_cloud_collection_summary
@@ -14,10 +14,10 @@ cat << EOF
 
   Output:
   - crn_cloud_collection_summary.<date_str>.tsv
-  - subject_dataset_membership.<date_str>.tsv (excludes cohorts)
-  - sample_dataset_membership.<date_str>.tsv (excludes cohorts)
-  - brain_donor_dataset_membership.<date_str>.tsv (excludes cohorts)
-  - subject_diagnosis_membership.<date_str>.tsv
+  - crn_cloud_collection_summary.subject_dataset_membership.<date_str>.tsv (excludes cohorts)
+  - crn_cloud_collection_summary.sample_dataset_membership.<date_str>.tsv (excludes cohorts)
+  - crn_cloud_collection_summary.brain_donor_dataset_membership.<date_str>.tsv (excludes cohorts)
+  - crn_cloud_collection_summary.subject_diagnosis_membership.<date_str>.tsv
 
   Usage: $0 [OPTIONS]
 

--- a/util/crn_cloud_collection_summary
+++ b/util/crn_cloud_collection_summary
@@ -620,6 +620,8 @@ calculate_breakdown() {
         # Data assay/modality grouping logic
         if (bucket ~ /sc-rnaseq/ || bucket ~ /sn-rnaseq/) {
             grp["sc_sn"] += count
+        } else if (bucket ~ /sc-atacseq/ || bucket ~ /sn-atacseq/) {
+            grp["sc_sn_atac"] += count
         } else if (bucket ~ /bulk-rnaseq/) {
             grp["bulk"] += count
         } else if (bucket ~ /spatial/) {
@@ -629,9 +631,13 @@ calculate_breakdown() {
         } else if (bucket ~ /parsebio/) {
             grp["parsebio"] += count
         } else if (bucket ~ /multimodal/ || bucket ~ /multiome/ || bucket ~ /multiomics/) {
-            grp["multimodal"] += count
+            grp["multiome"] += count
         } else if (bucket ~ /metagenome/) {
             grp["metagenomics"] += count
+        } else if (bucket ~ /wgs/) {
+            grp["wgs"] += count
+        } else if (bucket ~ /genetics/ || bucket ~ /genotyp/ || bucket ~ /gwas/) {
+            grp["genetics"] += count
         } else {
             grp["other"] += count
             other_buckets[bucket] = 1
@@ -655,14 +661,17 @@ calculate_breakdown() {
         print ""
 
         print "=== BREAKDOWN BY DATA TYPE ==="
-        printf "sc/sn RNAseq: %d\n", grp["sc_sn"]
-        printf "bulk RNAseq:  %d\n", grp["bulk"]
-        printf "spatial:      %d\n", grp["spatial"]
-        printf "proteomics:   %d\n", grp["ms_p"]
-        printf "parsebio:     %d\n", grp["parsebio"]
-        printf "multimodal:   %d\n", grp["multimodal"]
-        printf "metagenomics: %d\n", grp["metagenomics"]
-        printf "other:        %d\n", grp["other"]
+        printf "sc/sn RNAseq:  %d\n", grp["sc_sn"]
+        printf "sc/sn ATACseq: %d\n", grp["sc_sn_atac"]
+        printf "sc/sn Multiome:%d\n", grp["multiome"]
+        printf "bulk RNAseq:   %d\n", grp["bulk"]
+        printf "spatial:       %d\n", grp["spatial"]
+        printf "proteomics:    %d\n", grp["ms_p"]
+        printf "parsebio:      %d\n", grp["parsebio"]
+        printf "genetics:      %d\n", grp["genetics"]
+        printf "wgs:           %d\n", grp["wgs"]
+        printf "metagenomics:  %d\n", grp["metagenomics"]
+        printf "other:         %d\n", grp["other"]
         print ""
 
         print "=== BUCKETS IN \"OTHER\" DATA MODALITY GROUP ==="

--- a/util/generate_dataset_summary_table
+++ b/util/generate_dataset_summary_table
@@ -399,55 +399,6 @@ def main():
             f.write(assay_ + "\t" + "\t".join(v.replace("\n", " / ") for v in row_vals) + "\n")
     print(f"Saved diagnosis table to {out_diag_tsv}")
 
-    # Save Excel
-    try:
-        import openpyxl
-        from openpyxl.styles import Font, Alignment, PatternFill
-        from openpyxl.utils import get_column_letter
-
-        out_xlsx = f"dataset_summary_table.{date_str}.xlsx"
-        wb = openpyxl.Workbook()
-        ws = wb.active
-        ws.title = "Summary"
-
-        fill_h = PatternFill("solid", fgColor="DCE6F1")
-        fill_m = PatternFill("solid", fgColor="EBF1DE")
-        bold   = Font(bold=True)
-        center = Alignment(horizontal="center", vertical="center")
-
-        ws.cell(1, 1, "Data type").font = bold
-        col = 2
-        for org, sources in [("Human", HUMAN_SOURCES_ORDER), ("Mouse", MOUSE_SOURCES_ORDER)]:
-            fill = fill_h if org == "Human" else fill_m
-            start = col
-            for _ in sources:
-                ws.cell(1, col).fill = fill
-                col += 1
-            ws.cell(1, start, org).font = Font(bold=True)
-            ws.cell(1, start).fill = fill
-            ws.cell(1, start).alignment = center
-            ws.merge_cells(start_row=1, start_column=start, end_row=1, end_column=col-1)
-
-        for i, (org, src) in enumerate(COL_KEYS):
-            c = ws.cell(2, i+2, src)
-            c.fill = fill_h if org == "Human" else fill_m
-            c.font = bold
-            c.alignment = center
-
-        for r, assay in enumerate(ASSAY_ORDER):
-            ws.cell(r+3, 1, assay).font = bold
-            for c, (org, src) in enumerate(COL_KEYS):
-                ws.cell(r+3, c+2, lookup.get((org, src, assay), "0/0")).alignment = center
-
-        ws.column_dimensions["A"].width = 24
-        for i in range(len(COL_KEYS)):
-            ws.column_dimensions[get_column_letter(i+2)].width = 22
-
-        wb.save(out_xlsx)
-        print(f"Saved Excel to {out_xlsx}")
-    except ImportError:
-        print("(openpyxl not installed — skipping Excel output)")
-
 
 if __name__ == "__main__":
     main()

--- a/util/generate_dataset_summary_table
+++ b/util/generate_dataset_summary_table
@@ -31,6 +31,8 @@ ASSAY_ORDER = [
     "Bulk RNA-seq",
     "Spatial Transcriptomics",
     "Proteomics",
+    "Metabolomics",
+    "Lipidomics",
     "Genetics",
     "WGS",
     "Metagenomics",
@@ -46,6 +48,9 @@ HUMAN_SOURCES_ORDER = [
 MOUSE_SOURCES_ORDER = [
     "Brain tissue",
     "Liver tissue",
+    "Lung tissue",
+    "Kidney tissue",
+    "Plasma",
     "Embryonic fibroblast",
     "Fecal",
 ]
@@ -75,6 +80,10 @@ def classify_assay(assay):
         return "Spatial Transcriptomics"
     if any(x in a for x in ["proteom", "ms-p", "mass_spec", "mass spec"]):
         return "Proteomics"
+    if any(x in a for x in ["metabolom", "ms-mb"]):
+        return "Metabolomics"
+    if any(x in a for x in ["lipidom", "ms-l"]):
+        return "Lipidomics"
     # WGS before Genetics — Genetics is the catch-all for genotyping/SNP/array data
     if any(x in a for x in ["wgs", "whole_genome", "whole-genome"]):
         return "WGS"
@@ -109,6 +118,12 @@ def classify_source(organism, sample_source):
         return "Fecal"
     if "liver" in s:
         return "Liver tissue"
+    if "lung" in s:
+        return "Lung tissue"
+    if "kidney" in s or "renal" in s:
+        return "Kidney tissue"
+    if any(x in s for x in ["plasma", "serum", "blood"]):
+        return "Plasma"
     if any(x in s for x in ["fibroblast", "mef", "embryon"]):
         return "Embryonic fibroblast"
     if any(x in s for x in ["fecal", "stool", "feces", "metagenom"]) and "mouse" in o:
@@ -128,10 +143,12 @@ def classify_organism_from_slug(slug):
         return "Human"
     if "mouse" in s or "sulzer-fecal-metagenome-fp-spf" in s:
         return "Mouse"
+    if "mef" in s or "mefs" in s:
+        return "Mouse"
     # Cell-line / in-vitro datasets — assume human unless slug also says mouse;
     # the bash scripts treat these as a separate origin but the pivot table only
     # has Human/Mouse, so default to Human (typical for iPSC/HEK293/etc.).
-    if any(x in s for x in ["invitro", "ipsc", "hek", "mef"]):
+    if any(x in s for x in ["invitro", "ipsc", "hek"]):
         return "Human" if "mouse" not in s else "Mouse"
     return None
 
@@ -150,6 +167,12 @@ def classify_source_from_slug(slug):
         return "Fecal"
     if "liver" in s:
         return "Liver tissue"
+    if "lung" in s:
+        return "Lung tissue"
+    if "kidney" in s or "renal" in s:
+        return "Kidney tissue"
+    if any(x in s for x in ["plasma", "serum", "-blood-"]) or s.endswith("-blood"):
+        return "Plasma"
     if any(x in s for x in ["invitro", "ipsc", "hek", "cell-line"]):
         return "Cell lines"
     return None
@@ -173,8 +196,13 @@ def classify_assay_from_slug(slug):
         return "Bulk RNA-seq"
     if any(x in s for x in ["spatial", "visium", "geomx", "cosmx", "xenium"]):
         return "Spatial Transcriptomics"
-    if any(x in s for x in ["-ms-", "proteom", "mass-spec"]):
+    # Mass-spec assays: tighten patterns so ms-p / ms-mb / ms-l don't collide
+    if any(x in s for x in ["ms-p-", "ms-p_", "proteom", "mass-spec"]) or s.endswith("ms-p"):
         return "Proteomics"
+    if any(x in s for x in ["ms-mb-", "ms-mb_", "metabolom"]) or s.endswith("ms-mb"):
+        return "Metabolomics"
+    if any(x in s for x in ["ms-l-", "ms-l_", "lipidom"]) or s.endswith("ms-l"):
+        return "Lipidomics"
     # WGS before Genetics — Genetics is the catch-all for genotyping/SNP/array data
     if any(x in s for x in ["wgs", "whole-genome"]):
         return "WGS"
@@ -316,7 +344,7 @@ def main():
     print(table.to_string())
 
     # Save TSV
-    date_str = pd.Timestamp.now().strftime("%Y-%m-%d")
+    date_str = pd.Timestamp.now().strftime("%Y-%m-%dT%H-%M-%S")
     out_tsv = f"dataset_summary_table.{date_str}.tsv"
     with open(out_tsv, "w") as f:
         f.write("\t" + "\t".join(o for o, s in COL_KEYS) + "\n")

--- a/util/generate_dataset_summary_table
+++ b/util/generate_dataset_summary_table
@@ -4,12 +4,16 @@ Generate a pivot table of unique subject/sample counts by organism x tissue type
 
 Usage:
     python3 generate_dataset_summary_table \
-        <crn_summary_tsv> \
+        <summary_tsv> \
         <subject_membership_tsv> \
         <sample_membership_tsv> \
         <subject_diagnosis_membership_tsv>
 
-All three files are outputs of the crn_cloud_collection_summary script.
+Works with output from either:
+  - crn_cloud_collection_summary (production datasets in Releases)
+  - internal_qc_dataset_collection_summary (pre-release datasets — slugs synthesized
+    from bucket names; classified by slug-name fallback since they're not in Releases)
+
 Subjects and samples are deduplicated globally across all team datasets.
 """
 
@@ -22,10 +26,13 @@ from common import get_releases_df
 
 ASSAY_ORDER = [
     "sc/snRNA-seq",
+    "sc/snATAC-seq",
+    "sc/sn Multiome",
     "Bulk RNA-seq",
     "Spatial Transcriptomics",
     "Proteomics",
     "Genetics",
+    "WGS",
     "Metagenomics",
 ]
 
@@ -51,6 +58,14 @@ COL_KEYS = (
 
 def classify_assay(assay):
     a = str(assay).lower()
+    # ATAC-seq first — the broader sc/sn regex below would otherwise capture sc_atac
+    if any(x in a for x in ["sc_atac", "sn_atac", "scatac", "snatac",
+                            "sc-atac", "sn-atac", "atacseq", "atac_seq", "atac-seq"]):
+        return "sc/snATAC-seq"
+    # Multiome (paired RNA+ATAC, e.g. 10x Multiome) — checked before sc/sn RNA-seq
+    # so the multimodal/multiome keyword takes precedence over a generic sc-/sn- match
+    if any(x in a for x in ["multimodal", "multiome", "multiomic"]):
+        return "sc/sn Multiome"
     if any(x in a for x in ["sc_", "sn_", "scrna", "snrna", "single_cell", "single_nucleus",
                               "sc-rna", "sn-rna", "scrnaseq", "snrnaseq"]):
         return "sc/snRNA-seq"
@@ -60,7 +75,10 @@ def classify_assay(assay):
         return "Spatial Transcriptomics"
     if any(x in a for x in ["proteom", "ms-p", "mass_spec", "mass spec"]):
         return "Proteomics"
-    if any(x in a for x in ["genetic", "genotyp", "wgs", "gwas", "snp", "variant"]):
+    # WGS before Genetics — Genetics is the catch-all for genotyping/SNP/array data
+    if any(x in a for x in ["wgs", "whole_genome", "whole-genome"]):
+        return "WGS"
+    if any(x in a for x in ["genetic", "genotyp", "gwas", "snp", "variant"]):
         return "Genetics"
     if any(x in a for x in ["metagenom", "shotgun", "fecal", "microbiome", "16s"]):
         return "Metagenomics"
@@ -98,6 +116,85 @@ def classify_source(organism, sample_source):
     return None
 
 
+# ---------------------------------------------------------------------------
+# Slug-based fallback classifiers (mirror patterns used in the bash scripts).
+# Used when a slug is not present in the Releases sheet — e.g. for pre-release
+# internal-QC datasets whose slug is synthesized from the GCS bucket name.
+# ---------------------------------------------------------------------------
+
+def classify_organism_from_slug(slug):
+    s = str(slug).lower()
+    if "human" in s or "pmdbs" in s:
+        return "Human"
+    if "mouse" in s or "sulzer-fecal-metagenome-fp-spf" in s:
+        return "Mouse"
+    # Cell-line / in-vitro datasets — assume human unless slug also says mouse;
+    # the bash scripts treat these as a separate origin but the pivot table only
+    # has Human/Mouse, so default to Human (typical for iPSC/HEK293/etc.).
+    if any(x in s for x in ["invitro", "ipsc", "hek", "mef"]):
+        return "Human" if "mouse" not in s else "Mouse"
+    return None
+
+
+def classify_source_from_slug(slug):
+    s = str(slug).lower()
+    # MEF = mouse embryonic fibroblast → must come before generic cell-line check
+    if "mef" in s:
+        return "Embryonic fibroblast"
+    if any(x in s for x in ["pmdbs", "brain", "midbrain", "striatum", "cortex",
+                            "substantia-nigra", "hippocampus", "cerebellum"]):
+        return "Brain tissue"
+    if any(x in s for x in ["colon", "gastro", "intestin", "gi-tract"]):
+        return "Gastrointestinal"
+    if any(x in s for x in ["fecal", "metagenome"]):
+        return "Fecal"
+    if "liver" in s:
+        return "Liver tissue"
+    if any(x in s for x in ["invitro", "ipsc", "hek", "cell-line"]):
+        return "Cell lines"
+    return None
+
+
+def classify_assay_from_slug(slug):
+    s = str(slug).lower()
+    # Order matters: more specific before more general.
+    # ATAC must come before RNA to avoid the sn-/sc- prefix catching atac variants.
+    if any(x in s for x in ["sn-atacseq", "sc-atacseq", "snatacseq", "scatacseq",
+                            "sn-atac", "sc-atac", "atac-seq", "atacseq"]):
+        return "sc/snATAC-seq"
+    # Multiome (paired RNA+ATAC) — checked before sc/sn RNA-seq so the
+    # multimodal/multiome keyword takes precedence over a generic sc-/sn- match
+    if any(x in s for x in ["multimodal", "multiome", "multiomic"]):
+        return "sc/sn Multiome"
+    if any(x in s for x in ["sn-rnaseq", "sc-rnaseq",
+                            "scrnaseq", "snrnaseq", "single-cell", "single-nucleus"]):
+        return "sc/snRNA-seq"
+    if "bulk-rnaseq" in s or "bulk" in s:
+        return "Bulk RNA-seq"
+    if any(x in s for x in ["spatial", "visium", "geomx", "cosmx", "xenium"]):
+        return "Spatial Transcriptomics"
+    if any(x in s for x in ["-ms-", "proteom", "mass-spec"]):
+        return "Proteomics"
+    # WGS before Genetics — Genetics is the catch-all for genotyping/SNP/array data
+    if any(x in s for x in ["wgs", "whole-genome"]):
+        return "WGS"
+    if any(x in s for x in ["genetic", "genotyp", "gwas"]):
+        return "Genetics"
+    if "metagenome" in s or "metagenomic" in s or "microbiome" in s:
+        return "Metagenomics"
+    return None
+
+
+def classify_slug_fallback(slug):
+    """Try slug-only classification; returns dict or None if not classifiable."""
+    org = classify_organism_from_slug(slug)
+    src = classify_source_from_slug(slug)
+    asy = classify_assay_from_slug(slug)
+    if org and src and asy:
+        return {"_organism": org, "_source": src, "_assay": asy}
+    return None
+
+
 def count_unique(mem_df, id_col, slug_to_meta):
     """Count unique IDs per (organism, source, assay) cell."""
     cell_ids = {}
@@ -132,15 +229,19 @@ def main():
         df.drop(df[df["publisher_slug"].str.contains("cohort", na=False)].index, inplace=True)
 
     print("Fetching Releases sheet...")
-    releases_df = get_releases_df()
-    meta = (releases_df[["prod_slug", "organism", "sample_source", "assay"]]
-            .dropna(subset=["prod_slug"])
-            .query("prod_slug != ''")
-            .copy())
-
-    meta["_organism"] = meta["organism"].apply(classify_organism)
-    meta["_source"]   = meta.apply(lambda r: classify_source(r["organism"], r["sample_source"]), axis=1)
-    meta["_assay"]    = meta["assay"].apply(classify_assay)
+    try:
+        releases_df = get_releases_df()
+        meta = (releases_df[["prod_slug", "organism", "sample_source", "assay"]]
+                .dropna(subset=["prod_slug"])
+                .query("prod_slug != ''")
+                .copy())
+        meta["_organism"] = meta["organism"].apply(classify_organism)
+        meta["_source"]   = meta.apply(lambda r: classify_source(r["organism"], r["sample_source"]), axis=1)
+        meta["_assay"]    = meta["assay"].apply(classify_assay)
+    except Exception as e:
+        print(f"  (Releases fetch failed: {e!r} — proceeding with slug-name classification only)")
+        meta = pd.DataFrame(columns=["prod_slug", "organism", "sample_source", "assay",
+                                       "_organism", "_source", "_assay"])
 
     OVERRIDES = {
         "prod-team-scherzer-pmdbs-genetics": {"_organism": "Human", "_source": "Brain tissue", "_assay": "Genetics"},
@@ -149,6 +250,37 @@ def main():
     meta = meta.dropna(subset=["_organism", "_source", "_assay"])
     slug_to_meta = meta.set_index("prod_slug")[["_organism", "_source", "_assay"]].to_dict("index")
     slug_to_meta.update(OVERRIDES)
+
+    # Fallback: any slug seen in the inputs but missing from Releases gets
+    # classified from the slug itself (mirrors bash-script bucket-name heuristics).
+    # This handles pre-release / internal-QC datasets whose slug is derived from
+    # the GCS bucket name rather than a Releases row.
+    input_slugs = set()
+    for df in [crn_df, subj_df, sample_df, diag_df]:
+        input_slugs.update(df["publisher_slug"].dropna().unique())
+
+    fallback_classified = []
+    fallback_unclassified = []
+    for slug in input_slugs - set(slug_to_meta):
+        m = classify_slug_fallback(slug)
+        if m:
+            slug_to_meta[slug] = m
+            fallback_classified.append(slug)
+        else:
+            fallback_unclassified.append(slug)
+
+    if fallback_classified:
+        print(f"\nClassified {len(fallback_classified)} slug(s) from slug-name fallback "
+              f"(not in Releases):")
+        for slug in sorted(fallback_classified):
+            m = slug_to_meta[slug]
+            print(f"  {slug} → {m['_organism']} / {m['_source']} / {m['_assay']}")
+
+    if fallback_unclassified:
+        print(f"\nWarning: {len(fallback_unclassified)} slug(s) could not be classified "
+              f"by Releases or by slug name (will be excluded from pivot):")
+        for slug in sorted(fallback_unclassified):
+            print(f"  {slug}")
 
     unmatched = meta[meta["_organism"].isna() | meta["_source"].isna() | meta["_assay"].isna()]
     unmatched = unmatched[~unmatched["prod_slug"].isin(OVERRIDES)]

--- a/util/internal_qc_dataset_collection_summary
+++ b/util/internal_qc_dataset_collection_summary
@@ -184,6 +184,9 @@ calculate_breakdown() {
         } else if (bucket ~ /metagenome/) {
             data_type_category = "metagenomics"
             grp["metagenomics"] += count
+        } else if (bucket ~ /wgs/) {
+            data_type_category = "wgs"
+            grp["wgs"] += count
         } else {
             data_type_category = "other"
             grp["other"] += count
@@ -225,6 +228,7 @@ calculate_breakdown() {
         printf "parsebio:     %d\n", grp["parsebio"]
         printf "multimodal:   %d\n", grp["multimodal"]
         printf "metagenomics: %d\n", grp["metagenomics"]
+        printf "wgs:          %d\n", grp["wgs"]
         printf "other:        %d\n", grp["other"]
         print ""
 
@@ -263,8 +267,10 @@ calculate_breakdown() {
             team_name = toupper(substr(team, 1, 1)) substr(team, 2)
             printf "Team %s:\n", team_name
             
-            if (team_data_type_category[team, "sc_sn"] > 0)
-                printf "  sc/sn RNAseq: %d\n", team_data_type_category[team, "sc_sn"]
+            if (team_data_type_category[team, "sc_sn_rna"] > 0)
+                printf "  sc/sn RNAseq: %d\n", team_data_type_category[team, "sc_sn_rna"]
+            if (team_data_type_category[team, "sc_sn_atac"] > 0)
+                printf "  sc/sn ATACseq: %d\n", team_data_type_category[team, "sc_sn_atac"]
             if (team_data_type_category[team, "bulk"] > 0)
                 printf "  bulk RNAseq:  %d\n", team_data_type_category[team, "bulk"]
             if (team_data_type_category[team, "spatial"] > 0)
@@ -277,6 +283,8 @@ calculate_breakdown() {
                 printf "  multimodal:   %d\n", team_data_type_category[team, "multimodal"]
             if (team_data_type_category[team, "metagenomics"] > 0)
                 printf "  metagenomics: %d\n", team_data_type_category[team, "metagenomics"]
+            if (team_data_type_category[team, "wgs"] > 0)
+                printf "  wgs: %d\n", team_data_type_category[team, "wgs"]
             if (team_data_type_category[team, "other"] > 0)
                 printf "  other:        %d\n", team_data_type_category[team, "other"]
             print ""

--- a/util/internal_qc_dataset_collection_summary
+++ b/util/internal_qc_dataset_collection_summary
@@ -44,10 +44,10 @@ output_file="internal_qc_dataset_collection_summary.$date_str.tsv"
 echo -e "publisher_slug\tteam\tgcp_raw_bucket\tgcp_raw_bucket_size\tsample_count\tsubject_count" > "$output_file"
 
 # Membership files (match CRN script's headers so the Python summary tool can read both)
-subject_membership_file="subject_dataset_membership.$date_str.tsv"
-sample_membership_file="sample_dataset_membership.$date_str.tsv"
-brain_donor_membership_file="brain_donor_dataset_membership.$date_str.tsv"
-subject_diagnosis_membership_file="subject_diagnosis_membership.$date_str.tsv"
+subject_membership_file="internal_qc_dataset_collection_summary.subject_dataset_membership.$date_str.tsv"
+sample_membership_file="internal_qc_dataset_collection_summary.sample_dataset_membership.$date_str.tsv"
+brain_donor_membership_file="internal_qc_dataset_collection_summary.brain_donor_dataset_membership.$date_str.tsv"
+subject_diagnosis_membership_file="internal_qc_dataset_collection_summary.subject_diagnosis_membership.$date_str.tsv"
 echo -e "subject_id\tpublisher_slug"      > "$subject_membership_file"
 echo -e "asap_sample_id\tpublisher_slug"  > "$sample_membership_file"
 echo -e "asap_subject_id\tpublisher_slug" > "$brain_donor_membership_file"
@@ -296,16 +296,41 @@ slug = sys.argv[1]
 out  = sys.argv[2]
 text = sys.stdin.read()
 
+import re
+
 # Diagnosis column priority: primary_diagnosis → last_diagnosis → path_autopsy_dx_main.
 # Try each in order, but skip a column if all its values are empty/NA (the column
 # exists but no row has a usable value — we want to fall through to the next one).
 NA_VALUES = {"", "na", "n/a", "none", "null", "nan", "-", "."}
+# Patterns that look like ages, dates, or other numeric data accidentally placed
+# in a diagnosis column. A real clinical diagnosis is never purely numeric.
+NUMERIC_LIKE_RE = re.compile(r"^[\d./\s-]+$")
 
-def values_for(reader_rows, col):
-    return [(r.get(col) or "").strip().strip("\"") for r in reader_rows]
+def is_usable_dx(v):
+    """A diagnosis value is usable if non-empty, not NA-like, and not purely
+    numeric (ages, dates, etc. sometimes end up in diagnosis columns)."""
+    if not v:
+        return False
+    low = v.lower()
+    if low in NA_VALUES:
+        return False
+    if NUMERIC_LIKE_RE.match(v):
+        return False
+    return True
 
-def has_usable_values(values):
-    return any(v and v.lower() not in NA_VALUES for v in values)
+def has_usable_values(rows, col):
+    """A column qualifies as a diagnosis source only if EVERY non-empty value is
+    a usable diagnosis. A single numeric/date-like value (age, year, etc.)
+    disqualifies the entire column — fall through to the next candidate."""
+    has_any = False
+    for r in rows:
+        v = (r.get(col) or "").strip().strip("\"")
+        if not v or v.lower() in NA_VALUES:
+            continue
+        if not is_usable_dx(v):
+            return False  # any non-diagnosis value kills this column
+        has_any = True
+    return has_any
 
 reader = csv.DictReader(io.StringIO(text))
 fields = reader.fieldnames or []
@@ -315,9 +340,9 @@ sub_key = norm.get("subject_id")
 rows = list(reader)  # materialize so we can inspect multiple columns
 
 dx_key = None
-for candidate in ("primary_diagnosis", "last_diagnosis", "path_autopsy_dx_main"):
+for candidate in ("primary_diagnosis", "last_diagnosis", "path_autopsy_dx_main", "path_autopsy_second_dx"):
     actual = norm.get(candidate)
-    if actual and has_usable_values(values_for(rows, actual)):
+    if actual and has_usable_values(rows, actual):
         dx_key = actual
         break
 
@@ -327,18 +352,18 @@ if not (sub_key and dx_key):
     sys.exit(0)
 
 # Log which diagnosis column was used (so we can verify fallback fired)
-print(f"USING_DX_COL:{dx_key}", file=sys.stderr)
+print("USING_DX_COL:" + dx_key, file=sys.stderr)
 n = 0
 with open(out, "a") as fh:
     for row in rows:
         sid = (row.get(sub_key) or "").strip().strip("\"")
         dx  = (row.get(dx_key)  or "").strip().strip("\"")
-        # Skip NA-like diagnosis values even when writing rows
-        if sid and dx and dx.lower() not in NA_VALUES:
+        # Skip NA-like and numeric-only diagnosis values
+        if sid and is_usable_dx(dx):
             # Tab/newline in values would break the TSV — replace with spaces
             sid = sid.replace("\t", " ").replace("\n", " ").replace("\r", " ")
             dx  = dx.replace("\t",  " ").replace("\n",  " ").replace("\r",  " ")
-            fh.write(f"{sid}\t{dx}\t{slug}\n")
+            fh.write(sid + "\t" + dx + "\t" + slug + "\n")
             n += 1
 print(n)
 ' "$publisher_slug" "$subject_diagnosis_membership_file" <<< "$clinpath_csv" 2> /tmp/_diag_stderr.txt || true)
@@ -492,9 +517,6 @@ calculate_breakdown() {
         } else if (bucket ~ /ms-p/) {
             data_type_category = "ms_p"
             grp["ms_p"] += count
-        } else if (bucket ~ /parsebio/) {
-            data_type_category = "parsebio"
-            grp["parsebio"] += count
         } else if (bucket ~ /multimodal/ || bucket ~ /multiome/ || bucket ~ /multiomics/) {
             data_type_category = "multimodal"
             grp["multimodal"] += count
@@ -542,7 +564,6 @@ calculate_breakdown() {
         printf "bulk RNAseq:  %d\n", grp["bulk"]
         printf "spatial:      %d\n", grp["spatial"]
         printf "proteomics:   %d\n", grp["ms_p"]
-        printf "parsebio:     %d\n", grp["parsebio"]
         printf "multimodal:   %d\n", grp["multimodal"]
         printf "metagenomics: %d\n", grp["metagenomics"]
         printf "wgs:          %d\n", grp["wgs"]
@@ -594,8 +615,6 @@ calculate_breakdown() {
                 printf "  spatial:      %d\n", team_data_type_category[team, "spatial"]
             if (team_data_type_category[team, "ms_p"] > 0)
                 printf "  proteomics:   %d\n", team_data_type_category[team, "ms_p"]
-            if (team_data_type_category[team, "parsebio"] > 0)
-                printf "  parsebio:     %d\n", team_data_type_category[team, "parsebio"]
             if (team_data_type_category[team, "multimodal"] > 0)
                 printf "  multimodal:   %d\n", team_data_type_category[team, "multimodal"]
             if (team_data_type_category[team, "metagenomics"] > 0)

--- a/util/internal_qc_dataset_collection_summary
+++ b/util/internal_qc_dataset_collection_summary
@@ -11,7 +11,12 @@ cat << EOF
   - Sample and subject breakdown is ongoing as more data modalities are being added
   - Sample and subject count can change as our Data Curators collaborate with CRN Teams to define this
     
-  Output: internal_qc_dataset_collection_summary.<date_str>.tsv
+  Output:
+  - internal_qc_dataset_collection_summary.<date_str>.tsv
+  - subject_dataset_membership.<date_str>.tsv
+  - sample_dataset_membership.<date_str>.tsv
+  - brain_donor_dataset_membership.<date_str>.tsv
+  - subject_diagnosis_membership.<date_str>.tsv
 
   Usage: $0 [OPTIONS]
 
@@ -36,32 +41,87 @@ done
 
 date_str=$(date +"%Y-%m-%d")
 output_file="internal_qc_dataset_collection_summary.$date_str.tsv"
-echo -e "team\tgcp_raw_bucket\tgcp_raw_bucket_size\tsample_count\tsubject_count" > "$output_file"
+echo -e "publisher_slug\tteam\tgcp_raw_bucket\tgcp_raw_bucket_size\tsample_count\tsubject_count" > "$output_file"
+
+# Membership files (match CRN script's headers so the Python summary tool can read both)
+subject_membership_file="subject_dataset_membership.$date_str.tsv"
+sample_membership_file="sample_dataset_membership.$date_str.tsv"
+brain_donor_membership_file="brain_donor_dataset_membership.$date_str.tsv"
+subject_diagnosis_membership_file="subject_diagnosis_membership.$date_str.tsv"
+echo -e "subject_id\tpublisher_slug"      > "$subject_membership_file"
+echo -e "asap_sample_id\tpublisher_slug"  > "$sample_membership_file"
+echo -e "asap_subject_id\tpublisher_slug" > "$brain_donor_membership_file"
+echo -e "asap_subject_id\tprimary_diagnosis\tpublisher_slug" > "$subject_diagnosis_membership_file"
 
 get_unique_column_count() {
     local csv_content="$1"
     local column_name="$2"
 
     local col_no
-    col_no=$(echo "$csv_content" \
-        | head -n 1 \
-        | tr "," "\n" \
-        | grep -n "^${column_name}$" \
-        | cut -d : -f 1)
+    col_no=$(awk -F',' -v col="$column_name" '
+        NR==1 {
+            for (i=1; i<=NF; i++) {
+                f=$i; gsub(/^"|"$|\r/, "", f)
+                if (f == col) { print i; exit }
+            }
+            exit
+        }
+    ' <<< "$csv_content")
 
     if [[ -z "$col_no" ]]; then
         echo ""
         return 0
     fi
 
-    echo "$csv_content" \
-        | cut -d "," -f "$col_no" \
-        | tail -n +2 \
-        | sed -r "/^\s*$/d" \
-        | sort -u \
-        | wc -l \
-        | tr -d '[:space:]'
+    awk -F',' -v c="$col_no" '
+        NR>1 {
+            v=$c; gsub(/^"|"$|\r/, "", v)
+            if (v ~ /[^[:space:]]/) print v
+        }
+    ' <<< "$csv_content" | sort -u | wc -l | tr -d '[:space:]'
 }
+
+# Extract distinct, non-empty values from a named column in a CSV string.
+# Strips surrounding quotes and CR. Prints one value per line.
+# Usage: get_unique_column_values <csv_content> <column_name>
+get_unique_column_values() {
+    local csv_content="$1"
+    local column_name="$2"
+
+    local col_no
+    col_no=$(awk -F',' -v col="$column_name" '
+        NR==1 {
+            for (i=1; i<=NF; i++) {
+                f=$i; gsub(/^"|"$|\r/, "", f)
+                if (f == col) { print i; exit }
+            }
+            exit
+        }
+    ' <<< "$csv_content")
+
+    if [[ -z "$col_no" ]]; then
+        return 0
+    fi
+
+    awk -F',' -v c="$col_no" '
+        NR>1 {
+            v=$c; gsub(/^"|"$|\r/, "", v)
+            if (v ~ /[^[:space:]]/) print v
+        }
+    ' <<< "$csv_content" | sort -u
+}
+
+# Temp files to collect IDs across all datasets for deduplication
+_HUMAN_IDS_FILE=$(mktemp /tmp/iqc_human_ids.XXXXXX)
+_MOUSE_IDS_FILE=$(mktemp /tmp/iqc_mouse_ids.XXXXXX)
+_CELL_IDS_FILE=$(mktemp /tmp/iqc_cell_ids.XXXXXX)
+_SAMPLE_IDS_FILE=$(mktemp /tmp/iqc_sample_ids.XXXXXX)
+_BRAIN_DONOR_IDS_FILE=$(mktemp /tmp/iqc_brain_donor_ids.XXXXXX)
+trap 'rm -f "$_HUMAN_IDS_FILE" "$_MOUSE_IDS_FILE" "$_CELL_IDS_FILE" "$_SAMPLE_IDS_FILE" "$_BRAIN_DONOR_IDS_FILE"' EXIT
+
+# Running totals (not deduped — same sample/donor in two datasets counts twice)
+total_brain_samples=0
+total_brain_donors=0
 
 
 if [[ -n "${DATASETS:-}" ]]; then
@@ -92,13 +152,20 @@ while IFS= read -r bucket; do
     team=$(echo "$bucket" | sed "s/^asap-raw-team-//" | cut -d'-' -f1)
     gcp_raw_bucket=$(echo "gs://$bucket")
 
+    # Synthesize CRN-style slug from bucket name so membership TSVs are interoperable
+    # gs://asap-raw-team-hafler-pmdbs-sn-rnaseq-pfc → prod-team-hafler-pmdbs-sn-rnaseq-pfc
+    publisher_slug="prod-${bucket#asap-raw-}"
+
     echo "Trying to get # of samples and subjects"
     sample_count="NA"
     subject_count="NA"
+    sample_csv=""
+    sample_csv_dir=""
     # First try: metadata/release/SAMPLE.csv
     if gcloud storage ls "$gcp_raw_bucket/metadata/release/SAMPLE.csv" &>/dev/null; then
         echo "  Found metadata/release/SAMPLE.csv"
         sample_csv=$(gcloud storage cat "$gcp_raw_bucket/metadata/release/SAMPLE.csv")
+        sample_csv_dir="$gcp_raw_bucket/metadata/release"
         sample_count=$(get_unique_column_count "$sample_csv" "sample_id")
         subject_count=$(get_unique_column_count "$sample_csv" "subject_id")
     else
@@ -109,10 +176,231 @@ while IFS= read -r bucket; do
         if [ -n "$sample_csv_loc" ]; then
             echo "  Found SAMPLE.csv at: $sample_csv_loc"
             sample_csv=$(gcloud storage cat "$sample_csv_loc")
+            sample_csv_dir="${sample_csv_loc%/SAMPLE.csv}"
             sample_count=$(get_unique_column_count "$sample_csv" "sample_id")
             subject_count=$(get_unique_column_count "$sample_csv" "subject_id")
         else
             echo "  No SAMPLE.csv found in metadata/ path"
+        fi
+    fi
+
+    # Collect IDs for global deduplication (only when SAMPLE.csv was found)
+    if [[ -n "$sample_csv" ]]; then
+        # Classify subject IDs by origin using bucket-name heuristic (mirrors CRN script)
+        if [[ "$bucket" == *human* ]] || [[ "$bucket" == *pmdbs* ]]; then
+            _dest_subject_file="$_HUMAN_IDS_FILE"
+        elif [[ "$bucket" == *mouse* ]] || [[ "$bucket" == *sulzer-fecal-metagenome-fp-spf* ]]; then
+            _dest_subject_file="$_MOUSE_IDS_FILE"
+        elif [[ "$bucket" == *cell* ]] || [[ "$bucket" == *invitro* ]] || [[ "$bucket" == *ipsc* ]] || [[ "$bucket" == *mef* ]]; then
+            _dest_subject_file="$_CELL_IDS_FILE"
+        else
+            _dest_subject_file=""
+        fi
+
+        if [[ -n "$_dest_subject_file" ]]; then
+            get_unique_column_values "$sample_csv" "subject_id" >> "$_dest_subject_file"
+        fi
+        get_unique_column_values "$sample_csv" "sample_id" >> "$_SAMPLE_IDS_FILE"
+
+        # Write membership rows: <id>\t<publisher_slug>
+        get_unique_column_values "$sample_csv" "subject_id" \
+            | awk -v slug="$publisher_slug" 'NF { print $0 "\t" slug }' \
+            >> "$subject_membership_file"
+        get_unique_column_values "$sample_csv" "sample_id" \
+            | awk -v slug="$publisher_slug" 'NF { print $0 "\t" slug }' \
+            >> "$sample_membership_file"
+
+        # Brain sample / donor logic mirrors CRN cloud script:
+        #   1. Brain samples (independent of CLINPATH):
+        #        - if PMDBS.csv exists → COUNT(DISTINCT sample_id) from PMDBS
+        #        - else → COUNT(DISTINCT sample_id) from SAMPLE where lower(tissue) ~ /brain/
+        #   2. Brain donors (only if CLINPATH.csv exists):
+        #        - if PMDBS.csv exists → CLINPATH.subject_id ∩ SAMPLE.subject_id where SAMPLE.sample_id ∈ PMDBS
+        #        - else if SAMPLE has any non-null region_level_1 → CLINPATH.subject_id ∩ SAMPLE.subject_id where SAMPLE.region_level_1 is non-null
+        if [[ -n "$sample_csv_dir" ]]; then
+            pmdbs_loc="$sample_csv_dir/PMDBS.csv"
+            clinpath_loc="$sample_csv_dir/CLINPATH.csv"
+
+            # --- Brain sample count (independent of CLINPATH) ---
+            dataset_brain_samples=0
+            brain_sample_ids=""
+            if gcloud storage ls "$pmdbs_loc" &>/dev/null; then
+                pmdbs_csv=$(gcloud storage cat "$pmdbs_loc")
+                brain_sample_ids=$(get_unique_column_values "$pmdbs_csv" "sample_id")
+                if [[ -n "$brain_sample_ids" ]]; then
+                    dataset_brain_samples=$(echo "$brain_sample_ids" | grep -cv '^$' || true)
+                fi
+            else
+                # No PMDBS — count SAMPLE rows with tissue ~ /brain/i
+                tissue_brain_count=$(awk -F',' '
+                    NR==1 {
+                        for (i=1; i<=NF; i++) {
+                            if ($i == "sample_id") s_col = i
+                            if ($i == "tissue")    t_col = i
+                        }
+                        next
+                    }
+                    NR>1 && s_col && t_col {
+                        t = $t_col; gsub(/^"|"$|\r/, "", t)
+                        sid = $s_col; gsub(/^"|"$|\r/, "", sid)
+                        if (tolower(t) ~ /brain/ && sid != "") print sid
+                    }
+                ' <<< "$sample_csv" | sort -u | grep -cv '^$' || true)
+                dataset_brain_samples=${tissue_brain_count:-0}
+            fi
+            total_brain_samples=$(( total_brain_samples + dataset_brain_samples ))
+
+            # --- Brain donor count (only if CLINPATH exists) ---
+            # Try CLINPATH next to SAMPLE first, then fall back to a recursive search
+            # in metadata/ (mirrors the SAMPLE.csv lookup pattern).
+            if ! gcloud storage ls "$clinpath_loc" &>/dev/null; then
+                clinpath_loc_recursive=$(gcloud storage ls -r "$gcp_raw_bucket/metadata" 2>/dev/null | grep -i "CLINPATH.csv" | head -n 1 || true)
+                if [[ -n "$clinpath_loc_recursive" ]]; then
+                    echo "  CLINPATH.csv not next to SAMPLE.csv, found at: $clinpath_loc_recursive"
+                    clinpath_loc="$clinpath_loc_recursive"
+                fi
+            fi
+
+            dataset_brain_donors=0
+            if gcloud storage ls "$clinpath_loc" &>/dev/null; then
+                clinpath_csv=$(gcloud storage cat "$clinpath_loc")
+                clinpath_subjects=$(get_unique_column_values "$clinpath_csv" "subject_id")
+
+                # Write (subject_id, primary_diagnosis, slug) for human/PMDBS datasets — mirrors CRN logic.
+                # Use Python's csv module rather than awk -F',' because diagnosis fields can contain
+                # commas inside quotes (e.g. "Idiopathic PD, mild") which awk would split on.
+                if [[ "$bucket" == *human* ]] || [[ "$bucket" == *pmdbs* ]]; then
+                    diag_rows_written=$(python3 -c '
+import csv, io, sys
+slug = sys.argv[1]
+out  = sys.argv[2]
+text = sys.stdin.read()
+
+# Diagnosis column priority: primary_diagnosis → last_diagnosis → path_autopsy_dx_main.
+# Try each in order, but skip a column if all its values are empty/NA (the column
+# exists but no row has a usable value — we want to fall through to the next one).
+NA_VALUES = {"", "na", "n/a", "none", "null", "nan", "-", "."}
+
+def values_for(reader_rows, col):
+    return [(r.get(col) or "").strip().strip("\"") for r in reader_rows]
+
+def has_usable_values(values):
+    return any(v and v.lower() not in NA_VALUES for v in values)
+
+reader = csv.DictReader(io.StringIO(text))
+fields = reader.fieldnames or []
+# Strip whitespace/quotes/BOM from header names for robust matching
+norm = {f.strip().strip("\"").lstrip("\ufeff"): f for f in fields}
+sub_key = norm.get("subject_id")
+rows = list(reader)  # materialize so we can inspect multiple columns
+
+dx_key = None
+for candidate in ("primary_diagnosis", "last_diagnosis", "path_autopsy_dx_main"):
+    actual = norm.get(candidate)
+    if actual and has_usable_values(values_for(rows, actual)):
+        dx_key = actual
+        break
+
+if not (sub_key and dx_key):
+    print("MISSING_OR_EMPTY_DX_COLUMNS:" + ",".join(sorted(norm.keys())), file=sys.stderr)
+    print(0)
+    sys.exit(0)
+
+# Log which diagnosis column was used (so we can verify fallback fired)
+print(f"USING_DX_COL:{dx_key}", file=sys.stderr)
+n = 0
+with open(out, "a") as fh:
+    for row in rows:
+        sid = (row.get(sub_key) or "").strip().strip("\"")
+        dx  = (row.get(dx_key)  or "").strip().strip("\"")
+        # Skip NA-like diagnosis values even when writing rows
+        if sid and dx and dx.lower() not in NA_VALUES:
+            # Tab/newline in values would break the TSV — replace with spaces
+            sid = sid.replace("\t", " ").replace("\n", " ").replace("\r", " ")
+            dx  = dx.replace("\t",  " ").replace("\n",  " ").replace("\r",  " ")
+            fh.write(f"{sid}\t{dx}\t{slug}\n")
+            n += 1
+print(n)
+' "$publisher_slug" "$subject_diagnosis_membership_file" <<< "$clinpath_csv" 2> /tmp/_diag_stderr.txt || true)
+                    if [[ -s /tmp/_diag_stderr.txt ]]; then
+                        echo "  [diagnosis] $(cat /tmp/_diag_stderr.txt)"
+                    fi
+                    echo "  Wrote $diag_rows_written diagnosis rows from CLINPATH"
+                fi
+
+                # Decide which path to take: PMDBS join, region_level_1 fallback, or skip
+                _has_pmdbs=false
+                _has_region=false
+                [[ -n "$brain_sample_ids" ]] && _has_pmdbs=true
+                if ! "$_has_pmdbs"; then
+                    _region_check=$(awk -F',' '
+                        NR==1 { for (i=1; i<=NF; i++) if ($i == "region_level_1") r_col = i; next }
+                        NR>1 && r_col {
+                            r = $r_col; gsub(/^"|"$|\r/, "", r)
+                            if (r != "" && r != "NA") { c++ }
+                        }
+                        END { print c+0 }
+                    ' <<< "$sample_csv")
+                    [[ "${_region_check:-0}" -gt 0 ]] && _has_region=true
+                fi
+
+                brain_subjects=""
+                if "$_has_pmdbs"; then
+                    # CLINPATH ∩ SAMPLE.subject_id where SAMPLE.sample_id ∈ PMDBS
+                    brain_subjects=$(awk -F',' -v brain_ids="$brain_sample_ids" '
+                        BEGIN {
+                            n = split(brain_ids, arr, "\n")
+                            for (i=1; i<=n; i++) { gsub(/\r/, "", arr[i]); if (arr[i] != "") is_brain[arr[i]] = 1 }
+                        }
+                        NR==1 {
+                            for (i=1; i<=NF; i++) {
+                                if ($i == "sample_id")  s_col = i
+                                if ($i == "subject_id") sub_col = i
+                            }
+                            next
+                        }
+                        NR>1 && s_col && sub_col {
+                            sid = $s_col; gsub(/^"|"$|\r/, "", sid)
+                            sub_id = $sub_col; gsub(/^"|"$|\r/, "", sub_id)
+                            if (sid in is_brain && sub_id != "") print sub_id
+                        }
+                    ' <<< "$sample_csv" | sort -u)
+                elif "$_has_region"; then
+                    # CLINPATH ∩ SAMPLE.subject_id where SAMPLE.region_level_1 is non-null
+                    brain_subjects=$(awk -F',' '
+                        NR==1 {
+                            for (i=1; i<=NF; i++) {
+                                if ($i == "subject_id")    sub_col = i
+                                if ($i == "region_level_1") r_col = i
+                            }
+                            next
+                        }
+                        NR>1 && sub_col && r_col {
+                            r = $r_col; gsub(/^"|"$|\r/, "", r)
+                            sub_id = $sub_col; gsub(/^"|"$|\r/, "", sub_id)
+                            if (r != "" && r != "NA" && sub_id != "") print sub_id
+                        }
+                    ' <<< "$sample_csv" | sort -u)
+                fi
+
+                if [[ -n "$brain_subjects" ]] && [[ -n "$clinpath_subjects" ]]; then
+                    dataset_donors=$(comm -12 \
+                        <(echo "$clinpath_subjects" | sort -u) \
+                        <(echo "$brain_subjects"   | sort -u))
+                    if [[ -n "$dataset_donors" ]]; then
+                        dataset_brain_donors=$(echo "$dataset_donors" | grep -cv '^$' || true)
+                        echo "$dataset_donors" >> "$_BRAIN_DONOR_IDS_FILE"
+                        echo "$dataset_donors" \
+                            | awk -v slug="$publisher_slug" 'NF { print $0 "\t" slug }' \
+                            >> "$brain_donor_membership_file"
+                    fi
+                fi
+            else
+                if [[ "$bucket" == *human* ]] || [[ "$bucket" == *pmdbs* ]]; then
+                    echo "  [WARN] No CLINPATH.csv found in $gcp_raw_bucket/metadata — no diagnosis data for $publisher_slug"
+                fi
+            fi
+            total_brain_donors=$(( total_brain_donors + dataset_brain_donors ))
         fi
     fi
 
@@ -123,7 +411,7 @@ while IFS= read -r bucket; do
         gcp_raw_bucket_size=$(gcloud storage du -s "$gcp_raw_bucket" | grep -oE '^[0-9]+')
     fi
 
-    echo -e "${team}\t${gcp_raw_bucket}\t${gcp_raw_bucket_size}\t${sample_count}\t${subject_count}" >> "$output_file"
+    echo -e "${publisher_slug}\t${team}\t${gcp_raw_bucket}\t${gcp_raw_bucket_size}\t${sample_count}\t${subject_count}" >> "$output_file"
 done <<< "$RAW_BUCKETS"
 
 # Clean up
@@ -344,4 +632,64 @@ if ! "${SAMPLES_SUBJECTS_ONLY}"; then
     }' "$output_file"
 fi
 
+echo ""
+echo "========================================"
+echo "=== UNIQUE ID COUNTS ACROSS ALL DATASETS ==="
+n_unique_samples=$(sort -u "$_SAMPLE_IDS_FILE" 2>/dev/null | grep -cv '^$' || true)
+n_unique_samples=${n_unique_samples:-0}
+printf "Unique samples (sample_id) across all datasets: %d\n" "$n_unique_samples"
+
+printf "Total brain samples (with overlap):             %d\n" "$total_brain_samples"
+printf "Total brain donors (with overlap):              %d\n" "$total_brain_donors"
+n_unique_donors=$(sort -u "$_BRAIN_DONOR_IDS_FILE" 2>/dev/null | grep -cv '^$' || true)
+n_unique_donors=${n_unique_donors:-0}
+printf "Unique brain donors across all datasets:        %d\n" "$n_unique_donors"
+
+echo ""
+echo "=== SUBJECT ORIGIN BREAKDOWN ==="
+n_human_unique=$(sort -u "$_HUMAN_IDS_FILE" 2>/dev/null | grep -cv '^$' || true)
+n_mouse_unique=$(sort -u "$_MOUSE_IDS_FILE" 2>/dev/null | grep -cv '^$' || true)
+n_cell_unique=$(sort -u  "$_CELL_IDS_FILE"  2>/dev/null | grep -cv '^$' || true)
+n_human_unique=${n_human_unique:-0}
+n_mouse_unique=${n_mouse_unique:-0}
+n_cell_unique=${n_cell_unique:-0}
+n_total_unique=$(( n_human_unique + n_mouse_unique + n_cell_unique ))
+awk -F'\t' -v n_human_unique="$n_human_unique" -v n_mouse_unique="$n_mouse_unique" \
+            -v n_cell_unique="$n_cell_unique"   -v n_total_unique="$n_total_unique" '
+NR==1 {
+    for (i=1; i<=NF; i++) {
+        if ($i == "subject_count")  subj_col = i
+        if ($i == "gcp_raw_bucket") bucket_col = i
+    }
+    next
+}
+NR>1 {
+    if (subj_col > 0 && $subj_col ~ /^[0-9]+$/ && $subj_col+0 > 0) {
+        count = $subj_col+0
+        bucket = $bucket_col
+        total += count
+        if (bucket ~ /human/ || bucket ~ /pmdbs/)
+            origin["human"] += count
+        else if (bucket ~ /mouse/ || bucket ~ /sulzer-fecal-metagenome-fp-spf/)
+            origin["mouse"] += count
+        else if (bucket ~ /cell/ || bucket ~ /invitro/ || bucket ~ /ipsc/ || bucket ~ /mef/)
+            origin["cell"] += count
+        else
+            origin["other"] += count
+    }
+}
+END {
+    printf "%-30s %10s %10s\n", "", "all", "unique"
+    printf "%-30s %10d %10d\n", "human (subject_id):",     origin["human"], n_human_unique
+    printf "%-30s %10d %10d\n", "mouse (subject_id):",     origin["mouse"], n_mouse_unique
+    printf "%-30s %10d %10d\n", "cell  (subject_id):",     origin["cell"],  n_cell_unique
+    printf "%-30s %10d %10d\n", "other:",                  origin["other"], 0
+    printf "%-30s %10d %10d\n", "Total:",                  total,           n_total_unique
+}' "$output_file"
+
+echo ""
 echo "Saved results to [$(pwd)/$output_file]"
+echo "Saved subject membership to [$(pwd)/$subject_membership_file]"
+echo "Saved sample membership to [$(pwd)/$sample_membership_file]"
+echo "Saved brain donor membership to [$(pwd)/$brain_donor_membership_file]"
+echo "Saved subject diagnosis membership to [$(pwd)/$subject_diagnosis_membership_file]"

--- a/util/internal_qc_dataset_collection_summary
+++ b/util/internal_qc_dataset_collection_summary
@@ -53,6 +53,26 @@ echo -e "asap_sample_id\tpublisher_slug"  > "$sample_membership_file"
 echo -e "asap_subject_id\tpublisher_slug" > "$brain_donor_membership_file"
 echo -e "asap_subject_id\tprimary_diagnosis\tpublisher_slug" > "$subject_diagnosis_membership_file"
 
+# Normalize a CSV so that multi-line quoted fields are collapsed to a single line.
+# Embedded newlines (CR/LF) inside quoted fields are replaced with spaces.
+# Embedded commas and quotes are preserved. This makes the CSV safe to parse with
+# awk -F',' downstream (which can't handle multi-line quoted fields).
+# Usage: normalized=$(echo "$raw_csv" | normalize_csv)   OR   normalized=$(normalize_csv <<< "$raw_csv")
+normalize_csv() {
+    python3 -c '
+import csv, io, sys
+text = sys.stdin.read()
+if not text:
+    sys.exit(0)
+reader = csv.reader(io.StringIO(text))
+writer = csv.writer(sys.stdout, lineterminator="\n")
+for row in reader:
+    # Replace embedded newlines in any field with a space
+    cleaned = [c.replace("\r", " ").replace("\n", " ") for c in row]
+    writer.writerow(cleaned)
+'
+}
+
 get_unique_column_count() {
     local csv_content="$1"
     local column_name="$2"
@@ -164,7 +184,7 @@ while IFS= read -r bucket; do
     # First try: metadata/release/SAMPLE.csv
     if gcloud storage ls "$gcp_raw_bucket/metadata/release/SAMPLE.csv" &>/dev/null; then
         echo "  Found metadata/release/SAMPLE.csv"
-        sample_csv=$(gcloud storage cat "$gcp_raw_bucket/metadata/release/SAMPLE.csv")
+        sample_csv=$(gcloud storage cat "$gcp_raw_bucket/metadata/release/SAMPLE.csv" | normalize_csv)
         sample_csv_dir="$gcp_raw_bucket/metadata/release"
         sample_count=$(get_unique_column_count "$sample_csv" "sample_id")
         subject_count=$(get_unique_column_count "$sample_csv" "subject_id")
@@ -175,7 +195,7 @@ while IFS= read -r bucket; do
 
         if [ -n "$sample_csv_loc" ]; then
             echo "  Found SAMPLE.csv at: $sample_csv_loc"
-            sample_csv=$(gcloud storage cat "$sample_csv_loc")
+            sample_csv=$(gcloud storage cat "$sample_csv_loc" | normalize_csv)
             sample_csv_dir="${sample_csv_loc%/SAMPLE.csv}"
             sample_count=$(get_unique_column_count "$sample_csv" "sample_id")
             subject_count=$(get_unique_column_count "$sample_csv" "subject_id")
@@ -225,7 +245,7 @@ while IFS= read -r bucket; do
             dataset_brain_samples=0
             brain_sample_ids=""
             if gcloud storage ls "$pmdbs_loc" &>/dev/null; then
-                pmdbs_csv=$(gcloud storage cat "$pmdbs_loc")
+                pmdbs_csv=$(gcloud storage cat "$pmdbs_loc" | normalize_csv)
                 brain_sample_ids=$(get_unique_column_values "$pmdbs_csv" "sample_id")
                 if [[ -n "$brain_sample_ids" ]]; then
                     dataset_brain_samples=$(echo "$brain_sample_ids" | grep -cv '^$' || true)
@@ -263,7 +283,7 @@ while IFS= read -r bucket; do
 
             dataset_brain_donors=0
             if gcloud storage ls "$clinpath_loc" &>/dev/null; then
-                clinpath_csv=$(gcloud storage cat "$clinpath_loc")
+                clinpath_csv=$(gcloud storage cat "$clinpath_loc" | normalize_csv)
                 clinpath_subjects=$(get_unique_column_values "$clinpath_csv" "subject_id")
 
                 # Write (subject_id, primary_diagnosis, slug) for human/PMDBS datasets — mirrors CRN logic.
@@ -346,11 +366,19 @@ print(n)
 
                 brain_subjects=""
                 if "$_has_pmdbs"; then
-                    # CLINPATH ∩ SAMPLE.subject_id where SAMPLE.sample_id ∈ PMDBS
-                    brain_subjects=$(awk -F',' -v brain_ids="$brain_sample_ids" '
+                    # CLINPATH ∩ SAMPLE.subject_id where SAMPLE.sample_id ∈ PMDBS.
+                    # Write brain_sample_ids to a temp file rather than passing via -v —
+                    # BSD awk (macOS) rejects newlines inside -v argument values with
+                    # "newline in string" errors.
+                    _brain_ids_tmp=$(mktemp /tmp/iqc_brain_ids.XXXXXX)
+                    printf '%s\n' "$brain_sample_ids" > "$_brain_ids_tmp"
+                    brain_subjects=$(awk -F',' -v brain_ids_file="$_brain_ids_tmp" '
                         BEGIN {
-                            n = split(brain_ids, arr, "\n")
-                            for (i=1; i<=n; i++) { gsub(/\r/, "", arr[i]); if (arr[i] != "") is_brain[arr[i]] = 1 }
+                            while ((getline line < brain_ids_file) > 0) {
+                                gsub(/\r/, "", line)
+                                if (line != "") is_brain[line] = 1
+                            }
+                            close(brain_ids_file)
                         }
                         NR==1 {
                             for (i=1; i<=NF; i++) {
@@ -365,6 +393,7 @@ print(n)
                             if (sid in is_brain && sub_id != "") print sub_id
                         }
                     ' <<< "$sample_csv" | sort -u)
+                    rm -f "$_brain_ids_tmp"
                 elif "$_has_region"; then
                     # CLINPATH ∩ SAMPLE.subject_id where SAMPLE.region_level_1 is non-null
                     brain_subjects=$(awk -F',' '

--- a/util/internal_qc_dataset_collection_summary
+++ b/util/internal_qc_dataset_collection_summary
@@ -161,8 +161,11 @@ calculate_breakdown() {
         # Data assay/modality grouping logic
         data_type_category = ""
         if (bucket ~ /sc-rnaseq/ || bucket ~ /sn-rnaseq/) {
-            data_type_category = "sc_sn"
-            grp["sc_sn"] += count
+            data_type_category = "sc_sn_rna"
+            grp["sc_sn_rna"] += count
+        } else if (bucket ~ /sc-atacseq/ || bucket ~ /sn-atacseq/) {
+            data_type_category = "sc_sn_atac"
+            grp["sc_sn_atac"] += count
         } else if (bucket ~ /bulk-rnaseq/) {
             data_type_category = "bulk"
             grp["bulk"] += count
@@ -214,7 +217,8 @@ calculate_breakdown() {
         print ""
 
         printf "=== BREAKDOWN BY DATA TYPE ===\n"
-        printf "sc/sn RNAseq: %d\n", grp["sc_sn"]
+        printf "sc/sn RNAseq: %d\n", grp["sc_sn_rna"]
+        printf "sc/sn ATACseq: %d\n", grp["sc_sn_atac"]
         printf "bulk RNAseq:  %d\n", grp["bulk"]
         printf "spatial:      %d\n", grp["spatial"]
         printf "proteomics:   %d\n", grp["ms_p"]

--- a/util/internal_qc_dataset_collection_summary
+++ b/util/internal_qc_dataset_collection_summary
@@ -13,10 +13,10 @@ cat << EOF
     
   Output:
   - internal_qc_dataset_collection_summary.<date_str>.tsv
-  - subject_dataset_membership.<date_str>.tsv
-  - sample_dataset_membership.<date_str>.tsv
-  - brain_donor_dataset_membership.<date_str>.tsv
-  - subject_diagnosis_membership.<date_str>.tsv
+  - internal_qc_dataset_collection_summary.subject_dataset_membership.<date_str>.tsv
+  - internal_qc_dataset_collection_summary.sample_dataset_membership.<date_str>.tsv
+  - internal_qc_dataset_collection_summary.brain_donor_dataset_membership.<date_str>.tsv
+  - internal_qc_dataset_collection_summary.subject_diagnosis_membership.<date_str>.tsv
 
   Usage: $0 [OPTIONS]
 


### PR DESCRIPTION
## Description

Added internal QC dataset tracking and expand assay categories:
- Modified `internal_qc_dataset_collection_summary` script to mirrors the CRN cloud script for internal-QC buckets (asap-raw-team-*).
- Diagnosis extraction tries primary_diagnosis -> last_diagnosis -> path_autopsy_dx_main, treating NA-like values (NA, N/A, none, null, nan, -, .) as empty. Logs which column was used per dataset.
- `generate_dataset_summary_table` now accepts both CRN and internal-QC inputs. Slug-based fallback classifier added for datasets not in Releases (parses bucket-name patterns the same way the bash scripts do).
- Three new assay categories: sc/snATAC-seq, sc/sn Multiome (covers multimodal/multiome/multiomic), WGS, metabolomics, and lipidomics.

## Dependencies (Issues/PRs)

https://app.clickup.com/t/9014209604/BIOS-2260

## Type of Change

- [ ] Bug fix
- [x] New feature
- [x] Documentation

## Task Checklist

- [x] Documentation updated
- [x] Human reviewed any code produced or modified by AI
