### PR TITLE
Feature/brain bank stats

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -15,6 +15,8 @@ promote_staging_data_script.log
 *crn_cloud_collection_summary.*.tsv
 *internal_qc_dataset_collection_summary.*.tsv
 brain_bank*.tsv
+dataset_summary_table*.tsv
+subject_diagnosis_table*.tsv
 
 # Credentials
 *credentials.json

--- a/.gitignore
+++ b/.gitignore
@@ -11,9 +11,10 @@ promote_staging_data_script.log
 *workflow_version
 *VERSION
 
-# CRN Cloud Collection summary stats outputs
+# CRN Cloud summary stats outputs
 *crn_cloud_collection_summary.*.tsv
 *internal_qc_dataset_collection_summary.*.tsv
+brain_bank*.tsv
 
 # Credentials
 *credentials.json

--- a/util/README.md
+++ b/util/README.md
@@ -14,6 +14,8 @@
 | [`crn_cloud_collection_summary`](./crn_cloud_collection_summary) | Track the ASAP raw/curated buckets, size, sample breakdown, and subject breakdown in the CRN Cloud. | See [CRN Cloud Statistics](#crn-cloud-statistics) below for more details. | `./crn_cloud_collection_summary` |
 | [`internal_qc_dataset_collection_summary`](./internal_qc_dataset_collection_summary) | Track datasets in internal QC by getting their ASAP raw buckets, size, sample, and subject breakdown in GCP. | See [CRN Cloud Statistics](#crn-cloud-statistics) below for more details. | `./internal_qc_dataset_collection_summary` |
 | [`generate_dataset_summary_table`](./generate_dataset_summary_table) | Generate pivot tables of unique subject/sample counts and subject diagnosis counts by organism × tissue type × assay from CRN Cloud or internal QC summary outputs. | Run after `crn_cloud_collection_summary` or `internal_qc_dataset_collection_summary` to produce summary tables for reporting. Auto-detects input source from the filename and prefixes outputs accordingly. Reads dataset metadata from the Google Releases Sheet via `get_releases_df()` when available; falls back to slug-name classification otherwise. | `python3 generate_dataset_summary_table <prefix>.<date>.tsv <prefix>.subject_dataset_membership.<date>.tsv <prefix>.sample_dataset_membership.<date>.tsv <prefix>.subject_diagnosis_membership.<date>.tsv` |
+| [`extract_brain_bank_data`](./extract_brain_bank_data) | Extract brain bank (`biobank_name`) metadata for every PMDBS sample across CRN curated and/or internal QC raw buckets. | Walks `asap-curated-team-*` and `asap-raw-team-*` buckets, reads `SUBJECT.csv` + `SAMPLE.csv`, joins on `subject_id`, and emits one row per sample with its associated brain bank. Tracks attempted datasets and flags those skipped in both curated and internal QC. | `./extract_brain_bank_data` |
+| [`generate_brain_bank_summary`](./generate_brain_bank_summary) | Generate brain-bank-centric summary tables (matrix + long format) from the brain bank membership TSV. | Run after `extract_brain_bank_data` to produce brain-bank-focused summaries useful for identifying well-characterized samples vs. data gaps across data types. | `python3 generate_brain_bank_summary brain_bank_membership.<date>.tsv` |
 | [`transfer_release_resources_to_raw_bucket.py`](./transfer_release_resources_to_raw_bucket.py) | Sync local release-resources config/, release_stats/ and publisher_cards/ to dataset ASAP raw buckets. | After producing Publisher card text and summary figures, this script syncs locally stored files (presumably living at asap-crn-cloud-dataset-metadata/) into each dataset gs:// raw bucket. If any later changes are made to the release-resources, this script will need to be re-run to ensure that the raw bucket contains the most up to date copies. | `./transfer_release_resources_to_raw_bucket.py -i /path/to/release_<release_version>.json -p` |
 | [`clean_wdl_raw_buckets`](./clean_wdl_raw_buckets) | Clean up script for GCP raw bucket workflow execution timestamp cohort analysis and downstream folders. | Removes outdated timestamp folder contents across all raw buckets in the cohort analysis and downstream folders while preserving versions. | `./clean_wdl_raw_buckets -p` |
 
@@ -265,7 +267,7 @@ gcloud iam service-accounts keys create ~/.config/gspread/credentials.json \
 
 # CRN Cloud Statistics
 
-Utility scripts for tracking ASAP dataset statistics across the CRN Cloud and internal GCP infrastructure. Reports on bucket sizes, sample/subject counts, and breakdowns by data assay/modality and biological origin.
+Utility scripts for tracking ASAP dataset statistics across the CRN Cloud and internal GCP infrastructure. Reports on bucket sizes, sample/subject counts, brain bank coverage, and breakdowns by data assay/modality and biological origin.
 
 ## Scripts
 
@@ -402,9 +404,78 @@ python3 generate_dataset_summary_table \
 
 ---
 
+### `extract_brain_bank_data`
+
+Walks both CRN curated (`asap-curated-team-*`) and internal QC raw (`asap-raw-team-*`) buckets, locates `SUBJECT.csv` and `SAMPLE.csv` for each PMDBS dataset, joins them on `subject_id`, and emits one row per sample with its `biobank_name`. Designed to support brain-bank-centric reporting (which samples came from which bank, across which datasets and data types).
+
+**Output:**
+- `brain_bank_membership.<date>.tsv` — one row per sample-dataset pair
+
+| Column | Description |
+|--------|-------------|
+| `subject_id` | Subject identifier from `SUBJECT.csv` |
+| `sample_id` | Sample identifier from `SAMPLE.csv` |
+| `biobank_name` | Brain bank name from `SUBJECT.csv` |
+| `publisher_slug` | Dataset slug name, synthesized from bucket name as `prod-team-...` |
+| `source` | `crn` (from curated bucket) or `internal_qc` (from raw bucket) |
+
+**Usage:**
+```bash
+./extract_brain_bank_data [OPTIONS]
+
+OPTIONS
+  -h          Display this message and exit
+  -l FILE     Restrict to datasets listed in FILE (one slug per line, without the asap-{raw,curated}- prefix)
+  -s SRC      Which source(s) to scan: crn, internal_qc, or both (default: both)
+```
+
+**Notes:**
+- Requires `gcloud` authenticated with access to both `asap-curated-team-*` and `asap-raw-team-*` buckets, plus `python3` for CSV parsing
+- Only PMDBS buckets are scanned — `biobank_name` is meaningful only for postmortem brain tissue datasets
+- Cohort buckets (`cohort-*`) are skipped — they aggregate across teams and do not have a per-team `SUBJECT.csv`
+- `SAMPLE.csv` and `SUBJECT.csv` are searched first at `metadata/release/<name>.csv`, then recursively across `metadata/`
+- Each `gcloud storage cat` output is piped through a CSV normalizer that flattens multi-line quoted fields (e.g., GeoMX-style sample IDs) before parsing
+- After all buckets are processed, the script summarizes counts per source (CRN curated vs. internal QC) and deduplicated totals, then lists any datasets attempted in **both** CRN curated **and** internal QC that produced no output rows (missing `SUBJECT.csv`, missing `biobank_name`, empty join, etc.)
+
+---
+
+### `generate_brain_bank_summary`
+
+Generates two brain-bank-centric TSVs from the `brain_bank_membership.<date>.tsv` output of `extract_brain_bank_data`. Each unique `biobank_name` string is treated as a separate bank (no alias normalization) — sort the output to spot near-duplicate spellings manually.
+
+**Input:**
+- `brain_bank_membership.<date>.tsv` (output of `extract_brain_bank_data`)
+
+**Output:**
+- `brain_bank_summary_matrix.<date>.tsv` — matrix view: rows = brain banks, columns = data types. Each cell shows `samples / subjects (team)`. Right-side summary columns: `total_samples`, `total_subjects`, `n_data_types`, `n_subjects_multi_modality`, `sources`.
+- `brain_bank_summary_long.<date>.tsv` — long format, one row per (bank, team, data_type) for filtering or pivoting in Excel.
+
+| Column (long format) | Description |
+|--------|-------------|
+| `brain_bank` | Brain bank name as it appears in `biobank_name` |
+| `team` | Team name parsed from the dataset slug |
+| `data_type` | Assay category derived from the slug (sc/snRNA-seq, Spatial Transcriptomics, etc.) |
+| `in_crn` / `in_internal_qc` | Whether this (bank, team, data_type) cell has any rows from each source |
+| `n_samples` | Sample count for this cell |
+| `n_subjects` | Distinct subject count for this cell |
+| `n_subjects_multi_modality` | Subjects in this cell that also appear in ≥1 other data type for the same (bank, team) |
+| `datasets` | Semicolon-separated list of contributing datasets |
+
+**Usage:**
+```bash
+python3 generate_brain_bank_summary brain_bank_membership.<date>.tsv
+```
+
+**Notes:**
+- Data-type classification uses the same slug-name patterns as `generate_dataset_summary_table` so categories stay consistent across reports
+- The matrix sheet is sorted by `total_samples` descending — banks with the most data appear first; banks with sparse coverage and empty cells highlight where data gaps exist
+- `n_subjects_multi_modality` answers the "well-characterized samples" question: high values mean the same subject was profiled with multiple assays at the same bank+team
+
+---
+
 ## Summary Statistics
 
-Both scripts print a breakdown to stdout after writing the TSV, including counts grouped by:
+`crn_cloud_collection_summary` and `internal_qc_dataset_collection_summary` print a breakdown to stdout after writing the TSV, including counts grouped by:
 
 **Data assay/modality**
 | Group | Matched bucket patterns |
@@ -434,11 +505,13 @@ Buckets that fall into the `other` category are listed explicitly in the output 
 
 ## Dependencies
 
-- [`gcloud` CLI](https://cloud.google.com/sdk/gcloud) — required for `crn_cloud_collection_summary` and `internal_qc_dataset_collection_summary`
+- [`gcloud` CLI](https://cloud.google.com/sdk/gcloud) — required for `crn_cloud_collection_summary`, `internal_qc_dataset_collection_summary`, and `extract_brain_bank_data`
 - [`dnastack` CLI](https://docs.dnastack.com/docs/cli-overview) — required for `crn_cloud_collection_summary` only
 - `jq` — required for `crn_cloud_collection_summary`
-- `python3` (≥ 3.8) — required for `internal_qc_dataset_collection_summary` and `generate_dataset_summary_table`
-- `pandas`, `gspread` — required for `generate_dataset_summary_table`; `gspread` is optional and only enables Releases-sheet-based classification
+- `python3` (≥ 3.8) — required for `internal_qc_dataset_collection_summary`, `extract_brain_bank_data`, `generate_dataset_summary_table`, and `generate_brain_bank_summary`
+- `pandas` — required for `generate_dataset_summary_table` and `generate_brain_bank_summary`
+- `gspread` (optional) — enables Releases-sheet-based classification in `generate_dataset_summary_table`
+- `openpyxl` (optional) — enables xlsx output in `generate_dataset_summary_table`
 
 # Helpful resources
 

--- a/util/README.md
+++ b/util/README.md
@@ -447,7 +447,7 @@ Generates two brain-bank-centric TSVs from the `brain_bank_membership.<date>.tsv
 - `brain_bank_membership.<date>.tsv` (output of `extract_brain_bank_data`)
 
 **Output:**
-- `brain_bank_summary_matrix.<date>.tsv` — matrix view: rows = brain banks, columns = data types. Each cell shows `samples / subjects (team)`. Right-side summary columns: `total_samples`, `total_subjects`, `n_data_types`, `n_subjects_multi_modality`, `sources`.
+- `brain_bank_summary_matrix.<date>.tsv` — matrix view: rows = brain banks, columns = data types. Each cell shows `subjects / samples (team)`. Right-side summary columns: `total_samples`, `total_subjects`, `n_data_types`, `n_subjects_multi_modality`, `sources`.
 - `brain_bank_summary_long.<date>.tsv` — long format, one row per (bank, team, data_type) for filtering or pivoting in Excel.
 
 | Column (long format) | Description |
@@ -456,7 +456,7 @@ Generates two brain-bank-centric TSVs from the `brain_bank_membership.<date>.tsv
 | `team` | Team name parsed from the dataset slug |
 | `data_type` | Assay category derived from the slug (sc/snRNA-seq, Spatial Transcriptomics, etc.) |
 | `in_crn` / `in_internal_qc` | Whether this (bank, team, data_type) cell has any rows from each source |
-| `n_samples` | Sample count for this cell |
+| `n_samples` | Distinct sample count for this cell |
 | `n_subjects` | Distinct subject count for this cell |
 | `n_subjects_multi_modality` | Subjects in this cell that also appear in ≥1 other data type for the same (bank, team) |
 | `datasets` | Semicolon-separated list of contributing datasets |

--- a/util/common.py
+++ b/util/common.py
@@ -57,6 +57,195 @@ completed_platforming_raw_buckets = (
 
 
 ######################################################################
+##### SLUG CLASSIFIERS AND ORDERED CATEGORY LISTS ####################
+######################################################################
+# Used by generate_dataset_summary_table and generate_brain_bank_summary
+# to categorize datasets by assay type, organism, and tissue source when
+# the Releases Sheet metadata isn't available (e.g., internal QC datasets).
+
+# Ordered list of assay/data-type categories. Matches the column order in
+# the dataset summary pivot tables. Add new categories here as they appear.
+ASSAY_ORDER = [
+	"sc/snRNA-seq",
+	"sc/snATAC-seq",
+	"sc/sn Multiome",
+	"Bulk RNA-seq",
+	"Spatial Transcriptomics",
+	"Proteomics",
+	"Metabolomics",
+	"Lipidomics",
+	"Genetics",
+	"WGS",
+	"Metagenomics",
+]
+
+HUMAN_SOURCES_ORDER = [
+	"Brain tissue",
+	"Cell lines",
+	"Gastrointestinal",
+	"Fecal",
+]
+
+MOUSE_SOURCES_ORDER = [
+	"Brain tissue",
+	"Liver tissue",
+	"Lung tissue",
+	"Kidney tissue",
+	"Plasma",
+	"Embryonic fibroblast",
+	"Fecal",
+]
+
+
+def team_from_slug(slug):
+	"""prod-team-hafler-pmdbs-... → hafler. Returns 'unknown' if the slug
+	does not match the expected prod-team-<name>-... shape."""
+	parts = str(slug).split("-")
+	if len(parts) >= 3 and parts[0] == "prod" and parts[1] == "team":
+		return parts[2]
+	return "unknown"
+
+
+def classify_assay(value):
+	"""Map an assay value (free-text Releases-Sheet `assay`, or a dataset slug)
+	to an entry in ASSAY_ORDER. Returns None if no pattern matches — callers
+	decide their own fallback (e.g. 'Unclassified').
+
+	The patterns cover both Releases-Sheet conventions (snake_case, free-text
+	like 'Bulk_RNA_Seq', 'mass spec') and slug conventions (kebab-case like
+	'sc-rnaseq', 'ms-mb-plasma'). Order matters: more specific patterns are
+	checked before more general ones."""
+	s = str(value).lower()
+
+	# ATAC-seq first — broader sc/sn would otherwise capture sc_atac/sn_atac
+	if any(x in s for x in [
+		"sn-atacseq", "sc-atacseq", "snatacseq", "scatacseq",
+		"sc_atac", "sn_atac", "scatac", "snatac",
+		"sc-atac", "sn-atac", "atacseq", "atac_seq", "atac-seq",
+	]):
+		return "sc/snATAC-seq"
+
+	# Multiome (paired RNA+ATAC, e.g. 10x Multiome) — checked before sc/sn RNA-seq
+	# so the multimodal/multiome keyword takes precedence over a generic sc-/sn- match
+	if any(x in s for x in ["multimodal", "multiome", "multiomic"]):
+		return "sc/sn Multiome"
+
+	# sc/sn RNA-seq — covers both kebab-case slugs and snake_case Sheet values
+	if any(x in s for x in [
+		"sn-rnaseq", "sc-rnaseq", "scrnaseq", "snrnaseq",
+		"single-cell", "single-nucleus", "single_cell", "single_nucleus",
+		"scrna", "snrna", "sc-rna", "sn-rna",
+		"sc_", "sn_",
+	]):
+		return "sc/snRNA-seq"
+
+	if "bulk" in s:
+		return "Bulk RNA-seq"
+
+	if any(x in s for x in ["spatial", "visium", "geomx", "cosmx", "xenium", "nanostring"]):
+		return "Spatial Transcriptomics"
+
+	# Mass-spec assays — tighten ms-p / ms-mb / ms-l patterns so they don't collide.
+	# Bare `ms-p` is allowed when it's the whole value (e.g. Sheet input "ms-p")
+	# or at the end of a slug; the slug-tightened `ms-p-` / `ms-p_` handles
+	# embedded positions.
+	if (any(x in s for x in ["ms-p-", "ms-p_", "proteom", "mass-spec", "mass_spec", "mass spec"])
+			or s.endswith("ms-p") or s == "ms-p"):
+		return "Proteomics"
+	if any(x in s for x in ["ms-mb-", "ms-mb_", "metabolom"]) or s.endswith("ms-mb") or s == "ms-mb":
+		return "Metabolomics"
+	if any(x in s for x in ["ms-l-", "ms-l_", "lipidom"]) or s.endswith("ms-l") or s == "ms-l":
+		return "Lipidomics"
+
+	# WGS before Genetics — Genetics is the catch-all for genotyping/SNP/array data
+	if any(x in s for x in ["wgs", "whole-genome", "whole_genome"]):
+		return "WGS"
+	if any(x in s for x in ["genetic", "genotyp", "gwas", "snp", "variant"]):
+		return "Genetics"
+	if any(x in s for x in ["metagenom", "shotgun", "microbiome", "16s"]):
+		return "Metagenomics"
+
+	return None
+
+
+def classify_organism(value):
+	"""Map an organism value (free-text Releases-Sheet `organism`, or a dataset
+	slug) to 'Human' or 'Mouse'. Returns None if neither matches.
+
+	Cell-line / in-vitro values default to Human unless the input also says
+	'mouse' (so a slug like prod-team-alessi-mefs-... resolves to Mouse via
+	the MEF check below)."""
+	s = str(value).lower()
+	# Human keywords (slug-side: pmdbs; Sheet-side: human, homo)
+	if any(x in s for x in ["human", "homo", "pmdbs"]):
+		return "Human"
+	# MEF first — must come before generic mouse check so it doesn't get
+	# swallowed by a slug that happens to contain 'mef' but not 'mouse'
+	if "mef" in s or "mefs" in s:
+		return "Mouse"
+	if any(x in s for x in ["mouse", "mus", "sulzer-fecal-metagenome-fp-spf"]):
+		return "Mouse"
+	# Cell-line / in-vitro datasets — assume Human unless the value also
+	# says mouse (caller decides further disambiguation if needed)
+	if any(x in s for x in ["invitro", "ipsc", "hek"]):
+		return "Human" if "mouse" not in s else "Mouse"
+	return None
+
+
+def classify_source(value, organism=""):
+	"""Map a tissue-source value (slug or Releases-Sheet `sample_source`) to an
+	entry in HUMAN_SOURCES_ORDER / MOUSE_SOURCES_ORDER. Returns None if no
+	pattern matches.
+
+	`organism` is optional and is used only to disambiguate Fecal samples
+	when relevant. Pass '' (the default) when classifying from a slug — Fecal
+	doesn't need disambiguation at the slug level since both Human Fecal and
+	Mouse Fecal collapse to the same 'Fecal' bucket.
+
+	When called from the Releases-Sheet path, pass the organism so Fecal can
+	be split by Human/Mouse appropriately (currently both still map to 'Fecal',
+	but the organism arg is preserved for future disambiguation needs)."""
+	s = str(value).lower()
+	o = str(organism).lower()
+
+	# MEF = mouse embryonic fibroblast → must come before generic cell-line check
+	if "mef" in s or "fibroblast" in s or "embryon" in s:
+		return "Embryonic fibroblast"
+
+	if any(x in s for x in [
+		"brain", "pmdbs", "postmortem", "midbrain", "striatum", "cortex",
+		"substantia-nigra", "substantia nigra",
+		"hippocampus", "cerebellum", "neural",
+	]):
+		return "Brain tissue"
+
+	if any(x in s for x in ["colon", "gastro", "intestin", "gi-tract", "gi tract", "gut"]):
+		return "Gastrointestinal"
+
+	# Fecal: handles both Human Fecal and Mouse Fecal. The organism arg lets
+	# callers route to bucket-specific behavior later; for now both return Fecal.
+	if any(x in s for x in ["fecal", "stool", "feces", "microbiome", "metagenom"]):
+		return "Fecal"
+
+	if "liver" in s:
+		return "Liver tissue"
+	if "lung" in s:
+		return "Lung tissue"
+	if "kidney" in s or "renal" in s:
+		return "Kidney tissue"
+	if any(x in s for x in ["plasma", "serum"]) or "-blood-" in s or s.endswith("-blood") or s == "blood":
+		return "Plasma"
+
+	if any(x in s for x in [
+		"cell line", "cell-line", "invitro", "in vitro", "ipsc", "hek",
+		"neuronal cell", "hesc", "hpsc",
+	]):
+		return "Cell lines"
+
+	return None
+
+
+######################################################################
 ##### PROMOTE QC'ED METADATA AND ARTIFACTS - RAW TO PROD SECTION #####
 ######################################################################
 def remove_internal_qc_label(bucket_name):

--- a/util/extract_brain_bank_data
+++ b/util/extract_brain_bank_data
@@ -1,0 +1,242 @@
+#!/bin/bash
+# extract_brain_bank_data
+#
+# Walks both CRN curated (asap-curated-team-*) and internal QC raw
+# (asap-raw-team-*) buckets, finds SUBJECT.csv + SAMPLE.csv for each PMDBS
+# dataset, and emits one row per sample with its brain bank.
+#
+# Output: brain_bank_membership.<date_str>.tsv
+#   columns: subject_id, sample_id, biobank_name, publisher_slug, source
+#   where `source` is "crn" or "internal_qc"
+#
+# Usage:
+#   ./extract_brain_bank_data [-l datasets.txt] [-s crn|internal_qc|both]
+#
+# Options:
+#   -l FILE   Restrict to datasets listed in FILE (one slug per line,
+#             without the asap-{raw,curated}- prefix)
+#   -s SRC    Which source(s) to scan (default: both)
+
+set -eEo pipefail
+
+SOURCES="both"
+DATASETS=""
+
+while getopts "l:s:h" OPTION; do
+    case "${OPTION}" in
+        l) DATASETS="$OPTARG" ;;
+        s) SOURCES="$OPTARG" ;;
+        h)
+            sed -n '2,/^$/p' "$0" | sed 's/^# \{0,1\}//'
+            exit 0
+            ;;
+        *) echo "Unknown option" >&2; exit 1 ;;
+    esac
+done
+
+case "$SOURCES" in
+    crn|internal_qc|both) ;;
+    *) echo "Invalid -s value: $SOURCES (expected crn|internal_qc|both)" >&2; exit 1 ;;
+esac
+
+date_str=$(date +"%Y-%m-%d")
+output_file="brain_bank_membership.${date_str}.tsv"
+echo -e "subject_id\tsample_id\tbiobank_name\tpublisher_slug\tsource" > "$output_file"
+
+# CSV normalizer — flattens multi-line quoted fields so awk -F',' is safe.
+normalize_csv() {
+    python3 -c '
+import csv, io, sys
+text = sys.stdin.read()
+if not text:
+    sys.exit(0)
+reader = csv.reader(io.StringIO(text))
+writer = csv.writer(sys.stdout, lineterminator="\n")
+for row in reader:
+    cleaned = [c.replace("\r", " ").replace("\n", " ") for c in row]
+    writer.writerow(cleaned)
+'
+}
+
+# Locate a metadata CSV in a bucket. Tries metadata/release/<NAME> first,
+# then recursively searches metadata/ for the first match. Prints the gs://
+# path, or empty if not found.
+find_metadata_csv() {
+    local bucket_uri="$1" csv_name="$2"
+    if gcloud storage ls "${bucket_uri}/metadata/release/${csv_name}" &>/dev/null; then
+        echo "${bucket_uri}/metadata/release/${csv_name}"
+        return 0
+    fi
+    gcloud storage ls -r "${bucket_uri}/metadata" 2>/dev/null \
+        | grep -i "/${csv_name}$" | head -n 1 || true
+}
+
+# Process a single bucket: read SAMPLE.csv + SUBJECT.csv, join on subject_id,
+# emit (subject_id, sample_id, biobank_name, slug, source) rows.
+process_bucket() {
+    local bucket="$1" source_label="$2"
+    local bucket_uri="gs://${bucket}"
+
+    # Skip non-PMDBS buckets — biobank_name only meaningful for postmortem brain
+    if [[ "$bucket" != *pmdbs* ]]; then
+        return 0
+    fi
+
+    echo "  [${source_label}] ${bucket}"
+
+    # Derive a publisher_slug consistent with the other scripts
+    local prefix
+    if [[ "$bucket" == asap-raw-* ]]; then
+        prefix="asap-raw-"
+    elif [[ "$bucket" == asap-curated-* ]]; then
+        prefix="asap-curated-"
+    else
+        prefix=""
+    fi
+    local publisher_slug="prod-${bucket#${prefix}}"
+
+    # Find SAMPLE.csv and SUBJECT.csv
+    local sample_loc subject_loc
+    sample_loc=$(find_metadata_csv "$bucket_uri" "SAMPLE.csv")
+    subject_loc=$(find_metadata_csv "$bucket_uri" "SUBJECT.csv")
+
+    if [[ -z "$sample_loc" ]]; then
+        echo "    [SKIP] no SAMPLE.csv found"
+        return 0
+    fi
+    if [[ -z "$subject_loc" ]]; then
+        echo "    [SKIP] no SUBJECT.csv found (no biobank_name source)"
+        return 0
+    fi
+
+    local sample_csv subject_csv
+    sample_csv=$(gcloud storage cat "$sample_loc" | normalize_csv)
+    subject_csv=$(gcloud storage cat "$subject_loc" | normalize_csv)
+
+    # Use Python's csv module to do the join — handles quoted/multi-line cells
+    # cleanly and avoids awk -F',' pitfalls.
+    local rows_written
+    rows_written=$(python3 -c '
+import csv, io, sys
+slug = sys.argv[1]; source = sys.argv[2]; out = sys.argv[3]
+
+def read_csv(text):
+    r = csv.DictReader(io.StringIO(text))
+    fields = r.fieldnames or []
+    norm = {f.strip().strip("\"").lstrip("\ufeff"): f for f in fields}
+    return list(r), norm
+
+sample_text  = sys.argv[4]
+subject_text = sys.argv[5]
+sample_rows, sn  = read_csv(sample_text)
+subject_rows, un = read_csv(subject_text)
+
+# Resolve column names (case-insensitive header tolerance via norm dict).
+sub_id_s  = sn.get("subject_id")
+samp_id_s = sn.get("sample_id")
+sub_id_u  = un.get("subject_id")
+biobank_u = un.get("biobank_name")
+
+problems = []
+if not sub_id_s:   problems.append("SAMPLE missing subject_id")
+if not samp_id_s:  problems.append("SAMPLE missing sample_id")
+if not sub_id_u:   problems.append("SUBJECT missing subject_id")
+if not biobank_u:  problems.append("SUBJECT missing biobank_name")
+if problems:
+    print("[SKIP] " + ", ".join(problems), file=sys.stderr)
+    print(0)
+    sys.exit(0)
+
+# Build subject_id -> biobank_name lookup
+sub_to_bank = {}
+for row in subject_rows:
+    sid = (row.get(sub_id_u) or "").strip().strip("\"")
+    bank = (row.get(biobank_u) or "").strip().strip("\"")
+    if sid and bank and bank.lower() not in ("", "na", "n/a", "none", "null", "nan"):
+        sub_to_bank[sid] = bank
+
+if not sub_to_bank:
+    print("[SKIP] SUBJECT has biobank_name column but all values empty/NA", file=sys.stderr)
+    print(0)
+    sys.exit(0)
+
+# Emit one row per sample
+n = 0
+with open(out, "a") as fh:
+    for row in sample_rows:
+        sub_id  = (row.get(sub_id_s)  or "").strip().strip("\"")
+        samp_id = (row.get(samp_id_s) or "").strip().strip("\"")
+        bank = sub_to_bank.get(sub_id, "")
+        if sub_id and samp_id and bank:
+            # Defensive: replace any tabs/newlines surviving normalization
+            cleaned = [v.replace("\t", " ").replace("\n", " ").replace("\r", " ")
+                       for v in (sub_id, samp_id, bank, slug, source)]
+            fh.write("\t".join(cleaned) + "\n")
+            n += 1
+print(n)
+' "$publisher_slug" "$source_label" "$output_file" "$sample_csv" "$subject_csv" 2>/tmp/_bb_stderr.txt || true)
+
+    if [[ -s /tmp/_bb_stderr.txt ]]; then
+        echo "    $(cat /tmp/_bb_stderr.txt)"
+    fi
+    echo "    Wrote ${rows_written:-0} rows"
+}
+
+# ---------------------------------------------------------------------------
+# Main: enumerate buckets per source and process them
+# ---------------------------------------------------------------------------
+
+process_source() {
+    local source_label="$1" bucket_filter="$2"
+
+    local all_buckets
+    if [[ -n "$DATASETS" ]]; then
+        # User-provided dataset list — prepend the correct prefix
+        local prefix
+        if [[ "$source_label" == "crn" ]]; then prefix="asap-curated-"
+        else                                    prefix="asap-raw-"; fi
+        all_buckets=$(sed "s;^;${prefix};g" "$DATASETS")
+    else
+        all_buckets=$(gcloud storage buckets list \
+            --format="value(name)" \
+            --filter="name:${bucket_filter}")
+    fi
+
+    # For internal_qc, additionally filter to those labeled "internal-qc-data"
+    if [[ "$source_label" == "internal_qc" ]]; then
+        local filtered=""
+        while IFS= read -r bucket; do
+            [[ -z "$bucket" ]] && continue
+            if gcloud storage buckets describe "gs://$bucket" \
+                --format="value(labels)" 2>/dev/null | grep -q "internal-qc-data"; then
+                filtered="${filtered}${bucket}"$'\n'
+            fi
+        done <<< "$all_buckets"
+        all_buckets="$filtered"
+    fi
+
+    while IFS= read -r bucket; do
+        [[ -z "$bucket" ]] && continue
+        process_bucket "$bucket" "$source_label"
+    done <<< "$all_buckets"
+}
+
+if [[ "$SOURCES" == "crn" || "$SOURCES" == "both" ]]; then
+    echo "=== Scanning CRN curated buckets ==="
+    process_source "crn" "asap-curated-team*"
+fi
+
+if [[ "$SOURCES" == "internal_qc" || "$SOURCES" == "both" ]]; then
+    echo "=== Scanning internal QC raw buckets ==="
+    process_source "internal_qc" "asap-raw-team*"
+fi
+
+# Summary
+total_rows=$(tail -n +2 "$output_file" | wc -l | tr -d '[:space:]')
+unique_banks=$(tail -n +2 "$output_file" | cut -f3 | sort -u | grep -cv '^$' || true)
+unique_slugs=$(tail -n +2 "$output_file" | cut -f4 | sort -u | grep -cv '^$' || true)
+echo ""
+echo "Wrote $total_rows rows to $output_file"
+echo "  Unique brain banks: ${unique_banks:-0}"
+echo "  Unique datasets:    ${unique_slugs:-0}"
+echo "Saved to [$(pwd)/$output_file]"

--- a/util/extract_brain_bank_data
+++ b/util/extract_brain_bank_data
@@ -43,6 +43,13 @@ date_str=$(date +"%Y-%m-%d")
 output_file="brain_bank_membership.${date_str}.tsv"
 echo -e "subject_id\tsample_id\tbiobank_name\tpublisher_slug\tsource" > "$output_file"
 
+# Attempted-datasets log: each line is "<source>\t<dataset_suffix>"
+# (dataset_suffix = bucket with the asap-curated-/asap-raw- prefix stripped)
+# After all processing, any (source, suffix) pair that appears here but has
+# no rows in the output TSV is reported as a skip.
+_ATTEMPTED_FILE=$(mktemp /tmp/bb_attempted.XXXXXX)
+trap 'rm -f "$_ATTEMPTED_FILE"' EXIT
+
 # CSV normalizer — flattens multi-line quoted fields so awk -F',' is safe.
 normalize_csv() {
     python3 -c '
@@ -94,6 +101,11 @@ process_bucket() {
         prefix=""
     fi
     local publisher_slug="prod-${bucket#${prefix}}"
+    local dataset_suffix="${bucket#${prefix}}"
+
+    # Log this dataset as attempted — we'll later check whether it produced
+    # any rows in the output TSV.
+    printf '%s\t%s\n' "$source_label" "$dataset_suffix" >> "$_ATTEMPTED_FILE"
 
     # Find SAMPLE.csv and SUBJECT.csv
     local sample_loc subject_loc
@@ -231,12 +243,84 @@ if [[ "$SOURCES" == "internal_qc" || "$SOURCES" == "both" ]]; then
     process_source "internal_qc" "asap-raw-team*"
 fi
 
-# Summary
-total_rows=$(tail -n +2 "$output_file" | wc -l | tr -d '[:space:]')
-unique_banks=$(tail -n +2 "$output_file" | cut -f3 | sort -u | grep -cv '^$' || true)
-unique_slugs=$(tail -n +2 "$output_file" | cut -f4 | sort -u | grep -cv '^$' || true)
+# Summary — broken down by source (curated CRN vs. internal QC) plus combined totals
 echo ""
-echo "Wrote $total_rows rows to $output_file"
-echo "  Unique brain banks: ${unique_banks:-0}"
-echo "  Unique datasets:    ${unique_slugs:-0}"
+echo "============================================================"
+echo "=== BRAIN BANK EXTRACTION SUMMARY ==="
+echo "============================================================"
+
+print_source_summary() {
+    local label="$1" source_value="$2"
+    local n_rows n_banks n_slugs n_subjects n_samples
+    n_rows=$(tail -n +2 "$output_file" | awk -F'\t' -v src="$source_value" '$5 == src' | wc -l | tr -d '[:space:]')
+    n_banks=$(tail -n +2 "$output_file" | awk -F'\t' -v src="$source_value" '$5 == src {print $3}' | sort -u | grep -cv '^$' || true)
+    n_slugs=$(tail -n +2 "$output_file" | awk -F'\t' -v src="$source_value" '$5 == src {print $4}' | sort -u | grep -cv '^$' || true)
+    n_subjects=$(tail -n +2 "$output_file" | awk -F'\t' -v src="$source_value" '$5 == src {print $1}' | sort -u | grep -cv '^$' || true)
+    n_samples=$(tail -n +2 "$output_file" | awk -F'\t' -v src="$source_value" '$5 == src {print $2}' | sort -u | grep -cv '^$' || true)
+    printf "%-30s rows=%-6s unique: subjects=%-5s samples=%-5s banks=%-3s datasets=%s\n" \
+        "$label" "${n_rows:-0}" "${n_subjects:-0}" "${n_samples:-0}" "${n_banks:-0}" "${n_slugs:-0}"
+}
+
+print_source_summary "CRN curated:"     "crn"
+print_source_summary "Internal QC:"     "internal_qc"
+
+# Combined totals (subjects/samples/banks deduplicated across both sources)
+total_rows=$(tail -n +2 "$output_file" | wc -l | tr -d '[:space:]')
+total_subjects=$(tail -n +2 "$output_file" | cut -f1 | sort -u | grep -cv '^$' || true)
+total_samples=$(tail -n +2 "$output_file" | cut -f2 | sort -u | grep -cv '^$' || true)
+total_banks=$(tail -n +2 "$output_file" | cut -f3 | sort -u | grep -cv '^$' || true)
+total_slugs=$(tail -n +2 "$output_file" | cut -f4 | sort -u | grep -cv '^$' || true)
+echo "------------------------------------------------------------"
+printf "%-30s rows=%-6s unique: subjects=%-5s samples=%-5s banks=%-3s datasets=%s\n" \
+    "TOTAL (dedup across both):" "$total_rows" "${total_subjects:-0}" "${total_samples:-0}" "${total_banks:-0}" "${total_slugs:-0}"
+
+# ----- Skipped datasets: attempted but produced no output rows -----
+# A dataset (identified by its suffix, the bucket name with the source prefix
+# stripped) is considered "skipped" if it appears in the attempted log but has
+# no rows in the output TSV for that (source, suffix) pair. Reasons can be:
+# missing SAMPLE.csv, missing SUBJECT.csv, missing/empty biobank_name column,
+# or simply no matching subject_id joins.
+if [[ -s "$_ATTEMPTED_FILE" ]]; then
+    # Build the set of (source, suffix) pairs that DID produce output
+    produced_file=$(mktemp /tmp/bb_produced.XXXXXX)
+    tail -n +2 "$output_file" \
+        | awk -F'\t' 'NF >= 5 {
+            slug = $4; source = $5
+            sub(/^prod-/, "", slug)
+            printf "%s\t%s\n", source, slug
+          }' \
+        | sort -u > "$produced_file"
+
+    # Sort attempted for diff
+    attempted_sorted=$(mktemp /tmp/bb_att_sorted.XXXXXX)
+    sort -u "$_ATTEMPTED_FILE" > "$attempted_sorted"
+
+    # Attempted minus produced = skipped
+    skipped_file=$(mktemp /tmp/bb_skipped.XXXXXX)
+    comm -23 "$attempted_sorted" "$produced_file" > "$skipped_file"
+    rm -f "$produced_file" "$attempted_sorted"
+
+    if [[ -s "$skipped_file" ]]; then
+        echo ""
+        echo "============================================================"
+        echo "=== SKIPPED DATASETS (no brain bank metadata found) ==="
+        echo "============================================================"
+
+        # Datasets skipped in BOTH — strip source column and intersect
+        crn_only=$(awk -F'\t' '$1 == "crn"         {print $2}' "$skipped_file" | sort -u)
+        iqc_only=$(awk -F'\t' '$1 == "internal_qc" {print $2}' "$skipped_file" | sort -u)
+        if [[ -n "$crn_only" ]] && [[ -n "$iqc_only" ]]; then
+            both=$(comm -12 <(echo "$crn_only") <(echo "$iqc_only"))
+            if [[ -n "$both" ]]; then
+                both_count=$(echo "$both" | wc -l | tr -d '[:space:]')
+                echo ""
+                echo "  Skipped in BOTH CRN curated AND internal QC ($both_count dataset(s)):"
+                echo "$both" | awk '{printf "    %s\n", $0}'
+            fi
+        fi
+    fi
+    rm -f "$skipped_file"
+fi
+
+echo ""
 echo "Saved to [$(pwd)/$output_file]"

--- a/util/generate_brain_bank_summary
+++ b/util/generate_brain_bank_summary
@@ -23,63 +23,24 @@ from collections import defaultdict
 
 import pandas as pd
 
-
-# ---------------------------------------------------------------------------
-# Slug → data type classification. Borrowed from generate_dataset_summary_table
-# (same patterns) so consistency is maintained without duplicating the file.
-# ---------------------------------------------------------------------------
-def classify_assay_from_slug(slug):
-    s = str(slug).lower()
-    if any(x in s for x in ["sn-atacseq", "sc-atacseq", "snatacseq", "scatacseq",
-                            "sn-atac", "sc-atac", "atac-seq", "atacseq"]):
-        return "sc/snATAC-seq"
-    if any(x in s for x in ["multimodal", "multiome", "multiomic"]):
-        return "sc/sn Multiome"
-    if any(x in s for x in ["sn-rnaseq", "sc-rnaseq", "scrnaseq", "snrnaseq",
-                            "single-cell", "single-nucleus"]):
-        return "sc/snRNA-seq"
-    if "bulk-rnaseq" in s or "bulk" in s:
-        return "Bulk RNA-seq"
-    if any(x in s for x in ["spatial", "visium", "geomx", "cosmx", "xenium"]):
-        return "Spatial Transcriptomics"
-    if "ms-p-" in s or "ms-p_" in s or "proteom" in s or "mass-spec" in s or s.endswith("ms-p"):
-        return "Proteomics"
-    if "ms-mb-" in s or "ms-mb_" in s or "metabolom" in s or s.endswith("ms-mb"):
-        return "Metabolomics"
-    if "ms-l-" in s or "ms-l_" in s or "lipidom" in s or s.endswith("ms-l"):
-        return "Lipidomics"
-    if any(x in s for x in ["wgs", "whole-genome"]):
-        return "WGS"
-    if any(x in s for x in ["genetic", "genotyp", "gwas"]):
-        return "Genetics"
-    if "metagenome" in s or "metagenomic" in s or "microbiome" in s:
-        return "Metagenomics"
-    return "Unclassified"
+sys.path.insert(0, os.path.dirname(os.path.abspath(__file__)))
+from common import (
+    ASSAY_ORDER,
+    classify_assay,
+    team_from_slug,
+)
 
 
-# Data type column ordering for the matrix sheet (matches generate_dataset_summary_table)
-DATA_TYPE_ORDER = [
-    "sc/snRNA-seq",
-    "sc/snATAC-seq",
-    "sc/sn Multiome",
-    "Bulk RNA-seq",
-    "Spatial Transcriptomics",
-    "Proteomics",
-    "Metabolomics",
-    "Lipidomics",
-    "Genetics",
-    "WGS",
-    "Metagenomics",
-    "Unclassified",
-]
+def classify_data_type(slug):
+    """Wrap common.classify_assay so unmatched slugs land in 'Unclassified'
+    instead of None — the matrix layer needs an explicit column for them."""
+    return classify_assay(slug) or "Unclassified"
 
 
-def team_from_slug(slug):
-    """prod-team-hafler-pmdbs-... → hafler"""
-    parts = str(slug).split("-")
-    if len(parts) >= 3 and parts[0] == "prod" and parts[1] == "team":
-        return parts[2]
-    return "unknown"
+# Data type column ordering for the matrix sheet. Mirrors common.ASSAY_ORDER
+# plus the "Unclassified" bucket appended at the end (so any datasets that
+# don't match a known pattern still get a column).
+DATA_TYPE_ORDER = ASSAY_ORDER + ["Unclassified"]
 
 
 # Bank-name alias map. Keys are lowercased+stripped raw names from SUBJECT.csv;
@@ -139,7 +100,7 @@ def main():
 
     bb_df["brain_bank"] = bb_df["biobank_name"].apply(normalize_bank)
     bb_df["team"]       = bb_df["publisher_slug"].apply(team_from_slug)
-    bb_df["data_type"]  = bb_df["publisher_slug"].apply(classify_assay_from_slug)
+    bb_df["data_type"]  = bb_df["publisher_slug"].apply(classify_data_type)
 
     # CDE 4.4 sanity check: warn (don't fail) when a normalized bank name is
     # not in the CDE-recognized vocabulary. "Unknown" rows are ignored — those

--- a/util/generate_brain_bank_summary
+++ b/util/generate_brain_bank_summary
@@ -161,8 +161,11 @@ def main():
 
     # ----- Aggregates -----
     # (bank, team, data_type) → counts, subjects, slugs, sources
+    # Both sample_ids and subject_ids are stored as sets so the same physical
+    # sample appearing in multiple datasets (e.g. midbrain + mtg using the
+    # same biobank donor) is counted once.
     cell_agg = defaultdict(lambda: {
-        "n_samples":   0,
+        "sample_ids":  set(),
         "subject_ids": set(),
         "slugs":       set(),
         "sources":     set(),
@@ -171,7 +174,8 @@ def main():
     for _, r in bb_df.iterrows():
         key = (r["brain_bank"], r["team"], r["data_type"])
         a = cell_agg[key]
-        a["n_samples"] += 1
+        if r.get("sample_id"):
+            a["sample_ids"].add(r["sample_id"])
         if r["subject_id"]:
             a["subject_ids"].add(r["subject_id"])
         a["slugs"].add(r["publisher_slug"].removeprefix("prod-"))
@@ -198,7 +202,7 @@ def main():
             "data_type":   dtype,
             "in_crn":          "Yes" if "crn"         in a["sources"] else "No",
             "in_internal_qc":  "Yes" if "internal_qc" in a["sources"] else "No",
-            "n_samples":   a["n_samples"],
+            "n_samples":   len(a["sample_ids"]),
             "n_subjects":  n_subjects,
             "n_subjects_multi_modality": multi_modality_count(bank, team, dtype, a["subject_ids"]),
             "datasets":    "; ".join(sorted(a["slugs"])),
@@ -219,25 +223,25 @@ def main():
     matrix_rows = []
     for bank in banks:
         row = {"brain_bank": bank}
-        bank_total_samples  = 0
+        bank_total_sample_ids = set()
         bank_subject_ids    = set()
         bank_data_types     = set()
 
         for dt in data_types_present:
-            cell_samples  = 0
-            cell_subjects = set()
-            cell_teams    = set()
+            cell_sample_ids = set()
+            cell_subjects   = set()
+            cell_teams      = set()
             for (b, t, d), a in cell_agg.items():
                 if b == bank and d == dt:
-                    cell_samples += a["n_samples"]
+                    cell_sample_ids.update(a["sample_ids"])
                     cell_subjects.update(a["subject_ids"])
                     cell_teams.add(t)
-            if cell_samples or cell_subjects:
+            if cell_sample_ids or cell_subjects:
                 bank_data_types.add(dt)
-                bank_total_samples += cell_samples
+                bank_total_sample_ids.update(cell_sample_ids)
                 bank_subject_ids.update(cell_subjects)
                 teams_str = ", ".join(sorted(cell_teams))
-                row[dt] = "%d / %d  (%s)" % (len(cell_subjects), cell_samples, teams_str)
+                row[dt] = "%d / %d  (%s)" % (len(cell_subjects), len(cell_sample_ids), teams_str)
             else:
                 row[dt] = ""
 
@@ -256,7 +260,7 @@ def main():
             if b == bank:
                 bank_sources.update(a["sources"])
 
-        row["total_samples"]        = bank_total_samples
+        row["total_samples"]        = len(bank_total_sample_ids)
         row["total_subjects"]       = len(bank_subject_ids)
         row["n_data_types"]         = len(bank_data_types)
         row["n_subjects_multi_modality"] = n_multi_bank

--- a/util/generate_brain_bank_summary
+++ b/util/generate_brain_bank_summary
@@ -82,14 +82,45 @@ def team_from_slug(slug):
     return "unknown"
 
 
+# Bank-name alias map. Keys are lowercased+stripped raw names from SUBJECT.csv;
+# values are the canonical display name we want to bucket them under.
+# Add entries here as new spelling variants surface.
+BANK_ALIASES = {
+    "qsbb_uk":                                                "QSBB UK",
+    "qsbb uk":                                                "QSBB UK",
+    "ucl queen square brain bank for neurological disorders (qsbb)": "QSBB UK",
+    "banner_sun_health_usa":                                  "Banner Sun Health Research Institute",
+    "banner sun health research institute":                   "Banner Sun Health Research Institute",
+    "bshri":                                                  "Banner Sun Health Research Institute",
+    "imperial_uk":                                            "Imperial UK",
+}
+
+# Brain banks recognized by the CDE 4.4 controlled vocabulary. A normalized
+# (post-alias) bank name not in this set triggers a warning so it can be
+# investigated and either added here or fixed upstream — but the script does
+# not error out.
+CDE_4_4_RECOGNIZED_BANKS = {
+    "Banner Sun Health Research Institute",
+    "QSBB UK",
+    "Cambridge Brain Bank",
+    "New York Brain Bank",
+    "Imperial UK",
+    "SBB",
+    "NKI/NYUGSOM",
+    "BMC",
+    "Edinburgh UK",
+}
+
+
 def normalize_bank(raw):
-    """Trim whitespace; treat empty/NA as 'Unknown'. No alias-mapping."""
+    """Trim whitespace; treat empty/NA as 'Unknown'. Apply alias map for known
+    variants. Unknown banks fall through with their raw name unchanged."""
     if raw is None:
         return "Unknown"
     s = str(raw).strip()
     if not s or s.lower() in {"na", "n/a", "none", "nan", ""}:
         return "Unknown"
-    return s
+    return BANK_ALIASES.get(s.lower(), s)
 
 
 # ---------------------------------------------------------------------------
@@ -109,6 +140,24 @@ def main():
     bb_df["brain_bank"] = bb_df["biobank_name"].apply(normalize_bank)
     bb_df["team"]       = bb_df["publisher_slug"].apply(team_from_slug)
     bb_df["data_type"]  = bb_df["publisher_slug"].apply(classify_assay_from_slug)
+
+    # CDE 4.4 sanity check: warn (don't fail) when a normalized bank name is
+    # not in the CDE-recognized vocabulary. "Unknown" rows are ignored — those
+    # are already a known data-quality issue surfaced via the Unknown bucket.
+    unrecognized = sorted({
+        b for b in bb_df["brain_bank"].unique()
+        if b not in CDE_4_4_RECOGNIZED_BANKS and b != "Unknown"
+    })
+    if unrecognized:
+        print()
+        print("WARNING: %d brain bank name(s) not in the CDE 4.4 recognized list:"
+              % len(unrecognized))
+        for name in unrecognized:
+            n_rows = (bb_df["brain_bank"] == name).sum()
+            print("  - %r  (%d row(s))" % (name, n_rows))
+        print("  Add an entry to BANK_ALIASES if this is a known spelling variant,")
+        print("  or to CDE_4_4_RECOGNIZED_BANKS if this is a new canonical name.")
+        print()
 
     # ----- Aggregates -----
     # (bank, team, data_type) → counts, subjects, slugs, sources

--- a/util/generate_brain_bank_summary
+++ b/util/generate_brain_bank_summary
@@ -1,0 +1,242 @@
+#!/usr/bin/env python3
+"""
+Generate brain-bank-centric summary TSVs from the brain bank membership TSV.
+
+Outputs two TSV files:
+  - brain_bank_summary_matrix.<date>.tsv — matrix view. Rows = brain banks,
+    cols = data types. Each cell shows "samples / subjects (team)".
+    Summary columns on the right: total samples, total subjects, # distinct
+    data types, # multi-modality subjects (subjects with 2+ data types).
+  - brain_bank_summary_long.<date>.tsv — long format, one row per
+    (bank, team, data_type) for filtering/pivoting.
+
+Each unique biobank_name string is treated as a separate brain bank — no
+alias-mapping. Sort the table to spot near-duplicate spellings.
+
+Usage:
+  python3 generate_brain_bank_summary  brain_bank_membership.<date>.tsv
+"""
+import sys
+import os
+from datetime import datetime
+from collections import defaultdict
+
+import pandas as pd
+
+
+# ---------------------------------------------------------------------------
+# Slug → data type classification. Borrowed from generate_dataset_summary_table
+# (same patterns) so consistency is maintained without duplicating the file.
+# ---------------------------------------------------------------------------
+def classify_assay_from_slug(slug):
+    s = str(slug).lower()
+    if any(x in s for x in ["sn-atacseq", "sc-atacseq", "snatacseq", "scatacseq",
+                            "sn-atac", "sc-atac", "atac-seq", "atacseq"]):
+        return "sc/snATAC-seq"
+    if any(x in s for x in ["multimodal", "multiome", "multiomic"]):
+        return "sc/sn Multiome"
+    if any(x in s for x in ["sn-rnaseq", "sc-rnaseq", "scrnaseq", "snrnaseq",
+                            "single-cell", "single-nucleus"]):
+        return "sc/snRNA-seq"
+    if "bulk-rnaseq" in s or "bulk" in s:
+        return "Bulk RNA-seq"
+    if any(x in s for x in ["spatial", "visium", "geomx", "cosmx", "xenium"]):
+        return "Spatial Transcriptomics"
+    if "ms-p-" in s or "ms-p_" in s or "proteom" in s or "mass-spec" in s or s.endswith("ms-p"):
+        return "Proteomics"
+    if "ms-mb-" in s or "ms-mb_" in s or "metabolom" in s or s.endswith("ms-mb"):
+        return "Metabolomics"
+    if "ms-l-" in s or "ms-l_" in s or "lipidom" in s or s.endswith("ms-l"):
+        return "Lipidomics"
+    if any(x in s for x in ["wgs", "whole-genome"]):
+        return "WGS"
+    if any(x in s for x in ["genetic", "genotyp", "gwas"]):
+        return "Genetics"
+    if "metagenome" in s or "metagenomic" in s or "microbiome" in s:
+        return "Metagenomics"
+    return "Unclassified"
+
+
+# Data type column ordering for the matrix sheet (matches generate_dataset_summary_table)
+DATA_TYPE_ORDER = [
+    "sc/snRNA-seq",
+    "sc/snATAC-seq",
+    "sc/sn Multiome",
+    "Bulk RNA-seq",
+    "Spatial Transcriptomics",
+    "Proteomics",
+    "Metabolomics",
+    "Lipidomics",
+    "Genetics",
+    "WGS",
+    "Metagenomics",
+    "Unclassified",
+]
+
+
+def team_from_slug(slug):
+    """prod-team-hafler-pmdbs-... → hafler"""
+    parts = str(slug).split("-")
+    if len(parts) >= 3 and parts[0] == "prod" and parts[1] == "team":
+        return parts[2]
+    return "unknown"
+
+
+def normalize_bank(raw):
+    """Trim whitespace; treat empty/NA as 'Unknown'. No alias-mapping."""
+    if raw is None:
+        return "Unknown"
+    s = str(raw).strip()
+    if not s or s.lower() in {"na", "n/a", "none", "nan", ""}:
+        return "Unknown"
+    return s
+
+
+# ---------------------------------------------------------------------------
+# Main
+# ---------------------------------------------------------------------------
+def main():
+    if len(sys.argv) < 2:
+        print(__doc__)
+        sys.exit(1)
+
+    bb_path = sys.argv[1]
+
+    print("Loading inputs...")
+    bb_df = pd.read_csv(bb_path, sep="\t", dtype=str).fillna("")
+    print("  brain-bank rows: %d" % len(bb_df))
+
+    bb_df["brain_bank"] = bb_df["biobank_name"].apply(normalize_bank)
+    bb_df["team"]       = bb_df["publisher_slug"].apply(team_from_slug)
+    bb_df["data_type"]  = bb_df["publisher_slug"].apply(classify_assay_from_slug)
+
+    # ----- Aggregates -----
+    # (bank, team, data_type) → counts, subjects, slugs, sources
+    cell_agg = defaultdict(lambda: {
+        "n_samples":   0,
+        "subject_ids": set(),
+        "slugs":       set(),
+        "sources":     set(),
+    })
+
+    for _, r in bb_df.iterrows():
+        key = (r["brain_bank"], r["team"], r["data_type"])
+        a = cell_agg[key]
+        a["n_samples"] += 1
+        if r["subject_id"]:
+            a["subject_ids"].add(r["subject_id"])
+        a["slugs"].add(r["publisher_slug"].removeprefix("prod-"))
+        if r.get("source"):
+            a["sources"].add(r["source"])
+
+    # (bank, team) → subject → set(data_types)  -- for multi-modality
+    bt_subj_dtypes = defaultdict(lambda: defaultdict(set))
+    for _, r in bb_df.iterrows():
+        if r["subject_id"]:
+            bt_subj_dtypes[(r["brain_bank"], r["team"])][r["subject_id"]].add(r["data_type"])
+
+    def multi_modality_count(bank, team, data_type, subject_ids):
+        sd = bt_subj_dtypes.get((bank, team), {})
+        return sum(1 for sid in subject_ids if len(sd.get(sid, set())) >= 2)
+
+    # ----- Long-format rows (one per cell, for sheet 2) -----
+    long_rows = []
+    for (bank, team, dtype), a in cell_agg.items():
+        n_subjects = len(a["subject_ids"])
+        long_rows.append({
+            "brain_bank":  bank,
+            "team":        team,
+            "data_type":   dtype,
+            "in_crn":          "Yes" if "crn"         in a["sources"] else "No",
+            "in_internal_qc":  "Yes" if "internal_qc" in a["sources"] else "No",
+            "n_samples":   a["n_samples"],
+            "n_subjects":  n_subjects,
+            "n_subjects_multi_modality": multi_modality_count(bank, team, dtype, a["subject_ids"]),
+            "datasets":    "; ".join(sorted(a["slugs"])),
+        })
+    long_df = pd.DataFrame(long_rows).sort_values(
+        ["brain_bank", "team", "data_type"]
+    ).reset_index(drop=True)
+
+    # ----- Matrix view (bank rows × data_type columns) -----
+    # Build per-bank aggregates collapsed across teams + data_type cells
+    banks = sorted(bb_df["brain_bank"].unique())
+    data_types_present = [dt for dt in DATA_TYPE_ORDER
+                          if dt in set(bb_df["data_type"])]
+    # Append any unexpected data types we missed
+    for dt in sorted(set(bb_df["data_type"]) - set(data_types_present)):
+        data_types_present.append(dt)
+
+    matrix_rows = []
+    for bank in banks:
+        row = {"brain_bank": bank}
+        bank_total_samples  = 0
+        bank_subject_ids    = set()
+        bank_data_types     = set()
+
+        for dt in data_types_present:
+            cell_samples  = 0
+            cell_subjects = set()
+            cell_teams    = set()
+            for (b, t, d), a in cell_agg.items():
+                if b == bank and d == dt:
+                    cell_samples += a["n_samples"]
+                    cell_subjects.update(a["subject_ids"])
+                    cell_teams.add(t)
+            if cell_samples or cell_subjects:
+                bank_data_types.add(dt)
+                bank_total_samples += cell_samples
+                bank_subject_ids.update(cell_subjects)
+                teams_str = ", ".join(sorted(cell_teams))
+                row[dt] = "%d / %d  (%s)" % (len(cell_subjects), cell_samples, teams_str)
+            else:
+                row[dt] = ""
+
+        # Multi-modality across the whole bank: subjects appearing in 2+ data types
+        # at *any* team within this bank
+        subj_to_dtypes = defaultdict(set)
+        for (b, t), sd in bt_subj_dtypes.items():
+            if b != bank: continue
+            for sid, dts in sd.items():
+                subj_to_dtypes[sid].update(dts)
+        n_multi_bank = sum(1 for sid, dts in subj_to_dtypes.items() if len(dts) >= 2)
+
+        # Source(s) for this bank
+        bank_sources = set()
+        for (b, t, d), a in cell_agg.items():
+            if b == bank:
+                bank_sources.update(a["sources"])
+
+        row["total_samples"]        = bank_total_samples
+        row["total_subjects"]       = len(bank_subject_ids)
+        row["n_data_types"]         = len(bank_data_types)
+        row["n_subjects_multi_modality"] = n_multi_bank
+        row["sources"]              = ", ".join(sorted(bank_sources))
+        matrix_rows.append(row)
+
+    # Order matrix columns: brain_bank, [data types], summary cols
+    matrix_cols = (["brain_bank"]
+                   + data_types_present
+                   + ["total_samples", "total_subjects", "n_data_types",
+                      "n_subjects_multi_modality", "sources"])
+    matrix_df = pd.DataFrame(matrix_rows, columns=matrix_cols).sort_values(
+        ["total_samples", "brain_bank"], ascending=[False, True]
+    ).reset_index(drop=True)
+
+    # ----- Write TSVs -----
+    date_str = datetime.now().strftime("%Y-%m-%d")
+    matrix_path = "brain_bank_summary_matrix.%s.tsv" % date_str
+    long_path   = "brain_bank_summary_long.%s.tsv"   % date_str
+    matrix_df.to_csv(matrix_path, sep="\t", index=False)
+    long_df.to_csv(long_path,     sep="\t", index=False)
+
+    print()
+    print("Wrote %d banks to:" % len(matrix_df))
+    print("  %s  (matrix view: banks × data types)" % matrix_path)
+    print("  %s  (long format: one row per bank/team/data_type)" % long_path)
+    print("  Banks with multi-modality: %d" %
+          (matrix_df["n_subjects_multi_modality"] > 0).sum())
+
+
+if __name__ == "__main__":
+    main()

--- a/util/generate_dataset_summary_table
+++ b/util/generate_dataset_summary_table
@@ -22,38 +22,15 @@ import os
 import pandas as pd
 
 sys.path.insert(0, os.path.dirname(os.path.abspath(__file__)))
-from common import get_releases_df
-
-ASSAY_ORDER = [
-    "sc/snRNA-seq",
-    "sc/snATAC-seq",
-    "sc/sn Multiome",
-    "Bulk RNA-seq",
-    "Spatial Transcriptomics",
-    "Proteomics",
-    "Metabolomics",
-    "Lipidomics",
-    "Genetics",
-    "WGS",
-    "Metagenomics",
-]
-
-HUMAN_SOURCES_ORDER = [
-    "Brain tissue",
-    "Cell lines",
-    "Gastrointestinal",
-    "Fecal",
-]
-
-MOUSE_SOURCES_ORDER = [
-    "Brain tissue",
-    "Liver tissue",
-    "Lung tissue",
-    "Kidney tissue",
-    "Plasma",
-    "Embryonic fibroblast",
-    "Fecal",
-]
+from common import (
+    get_releases_df,
+    ASSAY_ORDER,
+    HUMAN_SOURCES_ORDER,
+    MOUSE_SOURCES_ORDER,
+    classify_assay,
+    classify_organism,
+    classify_source,
+)
 
 COL_KEYS = (
     [("Human", s) for s in HUMAN_SOURCES_ORDER] +
@@ -61,163 +38,20 @@ COL_KEYS = (
 )
 
 
-def classify_assay(assay):
-    a = str(assay).lower()
-    # ATAC-seq first — the broader sc/sn regex below would otherwise capture sc_atac
-    if any(x in a for x in ["sc_atac", "sn_atac", "scatac", "snatac",
-                            "sc-atac", "sn-atac", "atacseq", "atac_seq", "atac-seq"]):
-        return "sc/snATAC-seq"
-    # Multiome (paired RNA+ATAC, e.g. 10x Multiome) — checked before sc/sn RNA-seq
-    # so the multimodal/multiome keyword takes precedence over a generic sc-/sn- match
-    if any(x in a for x in ["multimodal", "multiome", "multiomic"]):
-        return "sc/sn Multiome"
-    if any(x in a for x in ["sc_", "sn_", "scrna", "snrna", "single_cell", "single_nucleus",
-                              "sc-rna", "sn-rna", "scrnaseq", "snrnaseq"]):
-        return "sc/snRNA-seq"
-    if "bulk" in a or a in ["bulk_rna_seq", "bulk_rnaseq"]:
-        return "Bulk RNA-seq"
-    if any(x in a for x in ["spatial", "visium", "geomx", "cosmx", "nanostring"]):
-        return "Spatial Transcriptomics"
-    if any(x in a for x in ["proteom", "ms-p", "mass_spec", "mass spec"]):
-        return "Proteomics"
-    if any(x in a for x in ["metabolom", "ms-mb"]):
-        return "Metabolomics"
-    if any(x in a for x in ["lipidom", "ms-l"]):
-        return "Lipidomics"
-    # WGS before Genetics — Genetics is the catch-all for genotyping/SNP/array data
-    if any(x in a for x in ["wgs", "whole_genome", "whole-genome"]):
-        return "WGS"
-    if any(x in a for x in ["genetic", "genotyp", "gwas", "snp", "variant"]):
-        return "Genetics"
-    if any(x in a for x in ["metagenom", "shotgun", "fecal", "microbiome", "16s"]):
-        return "Metagenomics"
-    return None
-
-
-def classify_organism(organism):
-    o = str(organism).lower()
-    if any(x in o for x in ["human", "homo"]):
-        return "Human"
-    if any(x in o for x in ["mouse", "mus"]):
-        return "Mouse"
-    return None
-
-
-def classify_source(organism, sample_source):
-    s = str(sample_source).lower()
-    o = str(organism).lower()
-    if any(x in s for x in ["brain", "pmdbs", "postmortem", "substantia nigra", "cortex",
-                              "striatum", "midbrain", "hippocampus", "cerebellum", "neural"])             or s.strip() == "brain":
-        return "Brain tissue"
-    if any(x in s for x in ["cell line", "invitro", "in vitro", "ipsc", "hek", "neuronal cell",
-                              "hesc", "hpsc"]):
-        return "Cell lines"
-    if any(x in s for x in ["colon", "gastro", "intestin", "gi tract", "gut"]):
-        return "Gastrointestinal"
-    if any(x in s for x in ["fecal", "stool", "feces", "microbiome"]) and "human" in o:
-        return "Fecal"
-    if "liver" in s:
-        return "Liver tissue"
-    if "lung" in s:
-        return "Lung tissue"
-    if "kidney" in s or "renal" in s:
-        return "Kidney tissue"
-    if any(x in s for x in ["plasma", "serum", "blood"]):
-        return "Plasma"
-    if any(x in s for x in ["fibroblast", "mef", "embryon"]):
-        return "Embryonic fibroblast"
-    if any(x in s for x in ["fecal", "stool", "feces", "metagenom"]) and "mouse" in o:
-        return "Fecal"
-    return None
-
-
 # ---------------------------------------------------------------------------
 # Slug-based fallback classifiers (mirror patterns used in the bash scripts).
 # Used when a slug is not present in the Releases sheet — e.g. for pre-release
 # internal-QC datasets whose slug is synthesized from the GCS bucket name.
+#
+# Classification logic lives in common.py — classify_assay / classify_organism /
+# classify_source each handle both Releases-Sheet values and slug inputs.
 # ---------------------------------------------------------------------------
-
-def classify_organism_from_slug(slug):
-    s = str(slug).lower()
-    if "human" in s or "pmdbs" in s:
-        return "Human"
-    if "mouse" in s or "sulzer-fecal-metagenome-fp-spf" in s:
-        return "Mouse"
-    if "mef" in s or "mefs" in s:
-        return "Mouse"
-    # Cell-line / in-vitro datasets — assume human unless slug also says mouse;
-    # the bash scripts treat these as a separate origin but the pivot table only
-    # has Human/Mouse, so default to Human (typical for iPSC/HEK293/etc.).
-    if any(x in s for x in ["invitro", "ipsc", "hek"]):
-        return "Human" if "mouse" not in s else "Mouse"
-    return None
-
-
-def classify_source_from_slug(slug):
-    s = str(slug).lower()
-    # MEF = mouse embryonic fibroblast → must come before generic cell-line check
-    if "mef" in s:
-        return "Embryonic fibroblast"
-    if any(x in s for x in ["pmdbs", "brain", "midbrain", "striatum", "cortex",
-                            "substantia-nigra", "hippocampus", "cerebellum"]):
-        return "Brain tissue"
-    if any(x in s for x in ["colon", "gastro", "intestin", "gi-tract"]):
-        return "Gastrointestinal"
-    if any(x in s for x in ["fecal", "metagenome"]):
-        return "Fecal"
-    if "liver" in s:
-        return "Liver tissue"
-    if "lung" in s:
-        return "Lung tissue"
-    if "kidney" in s or "renal" in s:
-        return "Kidney tissue"
-    if any(x in s for x in ["plasma", "serum", "-blood-"]) or s.endswith("-blood"):
-        return "Plasma"
-    if any(x in s for x in ["invitro", "ipsc", "hek", "cell-line"]):
-        return "Cell lines"
-    return None
-
-
-def classify_assay_from_slug(slug):
-    s = str(slug).lower()
-    # Order matters: more specific before more general.
-    # ATAC must come before RNA to avoid the sn-/sc- prefix catching atac variants.
-    if any(x in s for x in ["sn-atacseq", "sc-atacseq", "snatacseq", "scatacseq",
-                            "sn-atac", "sc-atac", "atac-seq", "atacseq"]):
-        return "sc/snATAC-seq"
-    # Multiome (paired RNA+ATAC) — checked before sc/sn RNA-seq so the
-    # multimodal/multiome keyword takes precedence over a generic sc-/sn- match
-    if any(x in s for x in ["multimodal", "multiome", "multiomic"]):
-        return "sc/sn Multiome"
-    if any(x in s for x in ["sn-rnaseq", "sc-rnaseq",
-                            "scrnaseq", "snrnaseq", "single-cell", "single-nucleus"]):
-        return "sc/snRNA-seq"
-    if "bulk-rnaseq" in s or "bulk" in s:
-        return "Bulk RNA-seq"
-    if any(x in s for x in ["spatial", "visium", "geomx", "cosmx", "xenium"]):
-        return "Spatial Transcriptomics"
-    # Mass-spec assays: tighten patterns so ms-p / ms-mb / ms-l don't collide
-    if any(x in s for x in ["ms-p-", "ms-p_", "proteom", "mass-spec"]) or s.endswith("ms-p"):
-        return "Proteomics"
-    if any(x in s for x in ["ms-mb-", "ms-mb_", "metabolom"]) or s.endswith("ms-mb"):
-        return "Metabolomics"
-    if any(x in s for x in ["ms-l-", "ms-l_", "lipidom"]) or s.endswith("ms-l"):
-        return "Lipidomics"
-    # WGS before Genetics — Genetics is the catch-all for genotyping/SNP/array data
-    if any(x in s for x in ["wgs", "whole-genome"]):
-        return "WGS"
-    if any(x in s for x in ["genetic", "genotyp", "gwas"]):
-        return "Genetics"
-    if "metagenome" in s or "metagenomic" in s or "microbiome" in s:
-        return "Metagenomics"
-    return None
-
 
 def classify_slug_fallback(slug):
     """Try slug-only classification; returns dict or None if not classifiable."""
-    org = classify_organism_from_slug(slug)
-    src = classify_source_from_slug(slug)
-    asy = classify_assay_from_slug(slug)
+    org = classify_organism(slug)
+    src = classify_source(slug)
+    asy = classify_assay(slug)
     if org and src and asy:
         return {"_organism": org, "_source": src, "_assay": asy}
     return None
@@ -264,7 +98,7 @@ def main():
                 .query("prod_slug != ''")
                 .copy())
         meta["_organism"] = meta["organism"].apply(classify_organism)
-        meta["_source"]   = meta.apply(lambda r: classify_source(r["organism"], r["sample_source"]), axis=1)
+        meta["_source"]   = meta.apply(lambda r: classify_source(r["sample_source"], r["organism"]), axis=1)
         meta["_assay"]    = meta["assay"].apply(classify_assay)
     except Exception as e:
         print(f"  (Releases fetch failed: {e!r} — proceeding with slug-name classification only)")


### PR DESCRIPTION
## Description

Adds two new utility scripts for brain-bank-centric reporting:
- `extract_brain_bank_data` - walks CRN curated (`asap-curated-team-*`) and internal QC/unreleased raw (`asap-raw-team-*`) PMDBS buckets, reads `SUBJECT.csv` + `SAMPLE.csv`, joins on `subject_id`, and emits `brain_bank_membership.<date>.tsv` (one row per sample with its `biobank_name`, dataset slug, and source).
- `generate_brain_bank_summary` - consumes the membership TSV and produces two summary TSVs: a bank × data-type matrix view and a long-format breakdown for filtering/pivoting.

### Notes

- Bank-name normalization via a small `BANK_ALIASES` dict (e.g., `BSHRI` → `Banner Sun Health Research Institute`). Names are checked against a `CDE_4_4_RECOGNIZED_BANKS` set from [ASAP_CDE](https://docs.google.com/spreadsheets/d/1c0z5KvRELdT2AtQAH2Dus8kwAyyLrR0CROhKOjpU4Vc/edit?gid=232892018#gid=232892018); unrecognized names print a warning but don't fail the run.
- Samples and subjects are deduplicated within each cell (same `sample_id` appearing in two datasets is counted once).

### Usage

```bash
./extract_brain_bank_data

python3 generate_brain_bank_summary brain_bank_membership.<date>.tsv
```

## Dependencies (Issues/PRs)

https://app.clickup.com/t/9014209604/BIOS-2264

## Type of Change

- [ ] Bug fix
- [x] New feature
- [x] Documentation

## Task Checklist

- [x] Documentation updated
- [x] Human reviewed any code produced or modified by AI
