### PR TITLE
Feature/moma table split brain subregion

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -17,6 +17,7 @@ promote_staging_data_script.log
 brain_bank*.tsv
 dataset_summary_table*.tsv
 subject_diagnosis_table*.tsv
+dataset_region_table*.tsv
 
 # Credentials
 *credentials.json

--- a/util/README.md
+++ b/util/README.md
@@ -281,6 +281,7 @@ Queries the [CRN Cloud](https://cloud.parkinsonsroadmap.org) via the DNAstack CL
 - `crn_cloud_collection_summary.sample_dataset_membership.<date>.tsv` — one row per sample-dataset pair (excludes cohorts)
 - `crn_cloud_collection_summary.brain_donor_dataset_membership.<date>.tsv` — one row per brain donor-dataset pair (excludes cohorts)
 - `crn_cloud_collection_summary.subject_diagnosis_membership.<date>.tsv` — one row per subject-diagnosis-dataset pair, human datasets only (CLINPATH → SUBJECT → SAMPLE `condition_id` priority order)
+- `crn_cloud_collection_summary.sample_region_dataset_membership.<date>.tsv` — one row per sample-dataset pair with brain region info (excludes cohorts; columns: `subject_id`, `asap_sample_id`, `region_level_1`, `region_level_2`, `publisher_slug`). Source priority: `SAMPLE.region_level_1` / `region_level_2` → `PMDBS.brain_region` (legacy CDE, populates `region_level_1` only). Samples without any region info are not emitted.
 
 | Column | Description |
 |--------|-------------|
@@ -335,6 +336,7 @@ Scans GCP directly for `asap-raw-team-*` buckets labelled `internal-qc-data` and
 - `internal_qc_dataset_collection_summary.sample_dataset_membership.<date>.tsv` — one row per sample-dataset pair
 - `internal_qc_dataset_collection_summary.brain_donor_dataset_membership.<date>.tsv` — one row per brain donor-dataset pair
 - `internal_qc_dataset_collection_summary.subject_diagnosis_membership.<date>.tsv` — one row per subject-diagnosis-dataset pair, human datasets only
+- `internal_qc_dataset_collection_summary.sample_region_dataset_membership.<date>.tsv` — one row per sample-dataset pair with brain region info (columns: `subject_id`, `asap_sample_id`, `region_level_1`, `region_level_2`, `publisher_slug`). Source priority: `SAMPLE.csv` `region_level_1` / `region_level_2` → `PMDBS.csv` `region_level_1` / `region_level_2` → `PMDBS.csv` `brain_region` (legacy CDE). Samples without any region info are not emitted.
 
 | Column | Description |
 |--------|-------------|
@@ -377,10 +379,12 @@ Generates pivot tables of unique subject/sample counts and subject diagnosis cou
 - `<prefix>.subject_dataset_membership.<date>.tsv`
 - `<prefix>.sample_dataset_membership.<date>.tsv`
 - `<prefix>.subject_diagnosis_membership.<date>.tsv`
+- `<prefix>.sample_region_dataset_membership.<date>.tsv` (optional; auto-discovered from the subject-membership path if omitted)
 
 **Output**:
 - `dataset_summary_table.<timestamp>.tsv` — table of unique subjects/samples by organism × tissue type × assay
 - `subject_diagnosis_table.<timestamp>.tsv` — table of unique subject diagnosis counts, human datasets only
+- `dataset_region_table.<timestamp>.tsv` — long-format table, one row per (dataset, `region_level_1`, `region_level_2`) with distinct `subject_count` and `sample_count`. Cohort slugs are excluded. Produced only when the sample-region membership file is present.
 
 **Usage:**
 ```bash
@@ -388,7 +392,8 @@ python3 generate_dataset_summary_table \
     <prefix>.<date>.tsv \
     <prefix>.subject_dataset_membership.<date>.tsv \
     <prefix>.sample_dataset_membership.<date>.tsv \
-    <prefix>.subject_diagnosis_membership.<date>.tsv
+    <prefix>.subject_diagnosis_membership.<date>.tsv \
+    [<prefix>.sample_region_dataset_membership.<date>.tsv]
 ```
 
 **Notes:**

--- a/util/README.md
+++ b/util/README.md
@@ -292,7 +292,9 @@ Queries the [CRN Cloud](https://cloud.parkinsonsroadmap.org) via the DNAstack CL
 | `gcp_curated_bucket_size` | Curated bucket size in bytes |
 | `team_name` | Contributing team name parsed from slug |
 | `n_samples` | Distinct `asap_sample_id` + `modality` count from ASSAY table; falls back to `COUNT(DISTINCT asap_sample_id)` from SAMPLE |
-| `n_subjects` | Subject count from SUBJECT, MOUSE, or CELL table (whichever applies); falls back to `COUNT(DISTINCT subject_id)` from SAMPLE |
+| `n_subjects_unique` | `COUNT(DISTINCT <subject-id-col>)` from team SAMPLE table where `<subject-id-col>` is `asap_subject_id`, `asap_mouse_id`, `asap_cell_id`, or `subject_id` (probed in that order); deduplicated subject count |
+| `n_samples_unique` | `COUNT(DISTINCT asap_sample_id)` from team SAMPLE table (deduplicated samples) |
+| `n_samples_total` | `COUNT(*)` of team SAMPLE table — raw row count, captures replicates of the same `asap_sample_id` |
 | `n_brain_samples` | Brain sample count from PMDBS table, or from `tissue` column in SAMPLE if no PMDBS table |
 | `n_brain_regions` | Distinct brain regions in PMDBS table |
 | `n_brain_donors` | Distinct donors in CLINPATH table |
@@ -344,8 +346,9 @@ Scans GCP directly for `asap-raw-team-*` buckets labelled `internal-qc-data` and
 | `team` | Team name parsed from bucket name |
 | `gcp_raw_bucket` | GCS raw bucket URI |
 | `gcp_raw_bucket_size` | Raw bucket size in bytes |
-| `sample_count` | Distinct `sample_id` count from `SAMPLE.csv` |
-| `subject_count` | Distinct `subject_id` count from `SAMPLE.csv` |
+| `n_subjects_unique` | Distinct `subject_id` count from `SAMPLE.csv` (deduplicated subjects) |
+| `n_samples_unique` | Distinct `sample_id` count from `SAMPLE.csv` (deduplicated samples) |
+| `n_samples_total` | Raw row count of `SAMPLE.csv` (header excluded) — captures replicates of the same `sample_id` |
 | `n_brain_samples` | Brain sample count from `PMDBS.csv` if present, else count of rows in `SAMPLE.csv` where `tissue ~ /brain/i` |
 | `n_brain_donors` | Distinct donors in `CLINPATH.csv` that also appear in `PMDBS.csv` (or `SAMPLE.region_level_1` if PMDBS not present) |
 | `n_subjects_<diagnosis>` | Per-diagnosis subject counts pulled from `CLINPATH.csv` (priority order: `primary_diagnosis` → `last_diagnosis` → `path_autopsy_dx_main` → `path_autopsy_second_dx`; any column with numeric-only values is skipped) |

--- a/util/crn_cloud_collection_summary
+++ b/util/crn_cloud_collection_summary
@@ -18,6 +18,7 @@ cat << EOF
   - crn_cloud_collection_summary.sample_dataset_membership.<date_str>.tsv (excludes cohorts)
   - crn_cloud_collection_summary.brain_donor_dataset_membership.<date_str>.tsv (excludes cohorts)
   - crn_cloud_collection_summary.subject_diagnosis_membership.<date_str>.tsv
+  - crn_cloud_collection_summary.sample_region_dataset_membership.<date_str>.tsv (excludes cohorts; one row per sample with brain region info)
 
   Usage: $0 [OPTIONS]
 
@@ -221,6 +222,8 @@ else
     echo -e "asap_subject_id\tprimary_diagnosis\tpublisher_slug" > "$subject_diagnosis_membership_file"
     sample_membership_file="crn_cloud_collection_summary.sample_dataset_membership.$date_str.tsv"
     echo -e "asap_sample_id\tpublisher_slug" > "$sample_membership_file"
+    sample_region_membership_file="crn_cloud_collection_summary.sample_region_dataset_membership.$date_str.tsv"
+    echo -e "subject_id\tasap_sample_id\tregion_level_1\tregion_level_2\tpublisher_slug" > "$sample_region_membership_file"
     echo -e "publisher_slug\tgcp_raw_bucket\tgcp_raw_bucket_size\tgcp_curated_bucket\tgcp_curated_bucket_size\tteam_name\tn_samples\tn_subjects\tn_brain_samples\tn_brain_regions\tn_brain_donors\tn_subjects_healthy_control\tn_subjects_idiopathic_pd\tn_subjects_alzheimers_disease\tn_subjects_frontotemporal_dementia\tn_subjects_corticobasal_syndrome\tn_subjects_dementia_with_lewy_bodies\tn_subjects_dopa_responsive_dystonia\tn_subjects_essential_tremor\tn_subjects_hemiparkinson_hemiatrophy_syndrome\tn_subjects_juvenile_autosomal_recessive_parkinsonism\tn_subjects_motor_neuron_disease_with_parkinsonism\tn_subjects_multiple_system_atrophy\tn_subjects_neuroleptic_induced_parkinsonism\tn_subjects_normal_pressure_hydrocephalus\tn_subjects_progressive_supranuclear_palsy\tn_subjects_psychogenic_parkinsonism\tn_subjects_vascular_parkinsonism\tn_subjects_no_pd_nor_other_neurological_disorder\tn_subjects_spinocerebellar_ataxia_sca\tn_subjects_prodromal_non_motor_pd\tn_subjects_prodromal_motor_pd\tn_subjects_crohns_disease\tn_subjects_crohns_disease_remission\tn_subjects_other_neurological_disorder\tn_subjects_other_non_neurological_disease_or_condition\tcondition_counts" > "$output_file"
 fi
 
@@ -407,6 +410,111 @@ while IFS= read -r slug; do
                     printf "%s\t%s\n" "$_sid" "$slug" >> "$sample_membership_file"
                 done < /tmp/_sample_ids_tmp.txt
             fi
+        fi
+    fi
+
+    # Sample region membership (one row per sample with brain region info).
+    # Source priority:
+    #   1. SAMPLE.region_level_1 / region_level_2 (CDE 4.x)
+    #   2. PMDBS.brain_region (legacy CDE; populates region_level_1 only)
+    # Samples with both region_level_1 and region_level_2 empty after both
+    # lookups are skipped — this keeps the file PMDBS-focused.
+    if [[ "${parts[1]:-}" != "cohort" ]] && echo "$collection_tables" | grep -qi "${team_name}_sample"; then
+        # Probe which region columns exist in SAMPLE
+        _sample_cols=$(dnastack collections query -c "$slug" \
+            "SELECT column_name FROM collections.information_schema.columns
+             WHERE table_schema = '$underscored_slug'
+               AND table_name = '${team_name}_sample'" \
+            -o csv 2>/dev/null | tail -n +2 | tr -d '\r,"' || true)
+        _has_rl1=false; _has_rl2=false
+        echo "$_sample_cols" | grep -qx "region_level_1" && _has_rl1=true
+        echo "$_sample_cols" | grep -qx "region_level_2" && _has_rl2=true
+
+        sample_region_csv=""
+        if $_has_rl1 || $_has_rl2; then
+            _rl1_expr="region_level_1"; $_has_rl1 || _rl1_expr="CAST(NULL AS VARCHAR)"
+            _rl2_expr="region_level_2"; $_has_rl2 || _rl2_expr="CAST(NULL AS VARCHAR)"
+            # asap_subject_id is the human SAMPLE subject column; for mouse/cell
+            # this returns NULL which is fine since we only emit rows with a
+            # populated region (PMDBS is human-only).
+            sample_region_csv=$(dnastack collections query -c "$slug" \
+                "SELECT DISTINCT asap_subject_id, asap_sample_id, $_rl1_expr AS region_level_1, $_rl2_expr AS region_level_2
+                 FROM \"collections\".\"$underscored_slug\".\"${team_name}_sample\"
+                 WHERE asap_sample_id IS NOT NULL" \
+                -o csv 2>/dev/null || true)
+        fi
+
+        # PMDBS.brain_region fallback (legacy CDE — region_level_1/2 absent).
+        # Join back through SAMPLE so we can carry asap_subject_id with the row.
+        pmdbs_region_csv=""
+        if echo "$collection_tables" | grep -qi "${team_name}_pmdbs"; then
+            if dnastack collections query -c "$slug" \
+                "SELECT column_name FROM collections.information_schema.columns
+                 WHERE table_schema = '$underscored_slug'
+                   AND table_name = '${team_name}_pmdbs'
+                   AND column_name = 'brain_region'
+                 LIMIT 1" \
+                -o csv 2>/dev/null | tail -n +2 | grep -q brain_region; then
+                pmdbs_region_csv=$(dnastack collections query -c "$slug" \
+                    "SELECT DISTINCT s.asap_subject_id, p.asap_sample_id, p.brain_region
+                     FROM \"collections\".\"$underscored_slug\".\"${team_name}_pmdbs\" p
+                     LEFT JOIN \"collections\".\"$underscored_slug\".\"${team_name}_sample\" s
+                       ON p.asap_sample_id = s.asap_sample_id
+                     WHERE p.asap_sample_id IS NOT NULL AND p.brain_region IS NOT NULL" \
+                    -o csv 2>/dev/null || true)
+            fi
+        fi
+
+        if [[ -n "$sample_region_csv" ]] || [[ -n "$pmdbs_region_csv" ]]; then
+            region_rows_written=$(python3 -c '
+import csv, io, sys
+slug = sys.argv[1]; out = sys.argv[2]
+sample_text = sys.argv[3]; pmdbs_text = sys.argv[4]
+
+NA = {"", "na", "n/a", "none", "null", "nan"}
+def clean(v):
+    s = (v or "").strip().strip("\"")
+    return "" if s.lower() in NA else s
+
+def read_csv(text):
+    if not text: return []
+    return list(csv.DictReader(io.StringIO(text)))
+
+# sample_id -> (subject_id, rl1, rl2) from SAMPLE
+sample_map = {}
+for r in read_csv(sample_text):
+    sid     = clean(r.get("asap_sample_id"))
+    subj_id = clean(r.get("asap_subject_id"))
+    rl1     = clean(r.get("region_level_1"))
+    rl2     = clean(r.get("region_level_2"))
+    if sid:
+        sample_map[sid] = (subj_id, rl1, rl2)
+
+# Apply PMDBS.brain_region fallback only where SAMPLE had no region info
+for r in read_csv(pmdbs_text):
+    sid     = clean(r.get("asap_sample_id"))
+    subj_id = clean(r.get("asap_subject_id"))
+    br      = clean(r.get("brain_region"))
+    if not sid or not br:
+        continue
+    existing = sample_map.get(sid, ("", "", ""))
+    ex_subj, ex_rl1, ex_rl2 = existing
+    if not ex_rl1 and not ex_rl2:
+        sample_map[sid] = (ex_subj or subj_id, br, "")
+
+# Emit rows where at least one region is populated
+n = 0
+with open(out, "a") as fh:
+    for sid, (subj_id, rl1, rl2) in sample_map.items():
+        if not rl1 and not rl2:
+            continue
+        cleaned = [v.replace("\t", " ").replace("\n", " ").replace("\r", " ")
+                   for v in (subj_id, sid, rl1, rl2, slug)]
+        fh.write("\t".join(cleaned) + "\n")
+        n += 1
+print(n)
+' "$slug" "$sample_region_membership_file" "$sample_region_csv" "$pmdbs_region_csv" 2>/dev/null || true)
+            echo "  Wrote ${region_rows_written:-0} sample-region rows"
         fi
     fi
 
@@ -934,3 +1042,4 @@ echo "Saved subject membership to [$(pwd)/$subject_membership_file]"
 echo "Saved sample membership to [$(pwd)/$sample_membership_file]"
 echo "Saved subject diagnosis membership to [$(pwd)/$subject_diagnosis_membership_file]"
 echo "Saved brain donor membership to [$(pwd)/$brain_donor_membership_file]"
+echo "Saved sample region membership to [$(pwd)/$sample_region_membership_file]"

--- a/util/crn_cloud_collection_summary
+++ b/util/crn_cloud_collection_summary
@@ -224,7 +224,7 @@ else
     echo -e "asap_sample_id\tpublisher_slug" > "$sample_membership_file"
     sample_region_membership_file="crn_cloud_collection_summary.sample_region_dataset_membership.$date_str.tsv"
     echo -e "subject_id\tasap_sample_id\tregion_level_1\tregion_level_2\tpublisher_slug" > "$sample_region_membership_file"
-    echo -e "publisher_slug\tgcp_raw_bucket\tgcp_raw_bucket_size\tgcp_curated_bucket\tgcp_curated_bucket_size\tteam_name\tn_samples\tn_subjects\tn_brain_samples\tn_brain_regions\tn_brain_donors\tn_subjects_healthy_control\tn_subjects_idiopathic_pd\tn_subjects_alzheimers_disease\tn_subjects_frontotemporal_dementia\tn_subjects_corticobasal_syndrome\tn_subjects_dementia_with_lewy_bodies\tn_subjects_dopa_responsive_dystonia\tn_subjects_essential_tremor\tn_subjects_hemiparkinson_hemiatrophy_syndrome\tn_subjects_juvenile_autosomal_recessive_parkinsonism\tn_subjects_motor_neuron_disease_with_parkinsonism\tn_subjects_multiple_system_atrophy\tn_subjects_neuroleptic_induced_parkinsonism\tn_subjects_normal_pressure_hydrocephalus\tn_subjects_progressive_supranuclear_palsy\tn_subjects_psychogenic_parkinsonism\tn_subjects_vascular_parkinsonism\tn_subjects_no_pd_nor_other_neurological_disorder\tn_subjects_spinocerebellar_ataxia_sca\tn_subjects_prodromal_non_motor_pd\tn_subjects_prodromal_motor_pd\tn_subjects_crohns_disease\tn_subjects_crohns_disease_remission\tn_subjects_other_neurological_disorder\tn_subjects_other_non_neurological_disease_or_condition\tcondition_counts" > "$output_file"
+    echo -e "publisher_slug\tgcp_raw_bucket\tgcp_raw_bucket_size\tgcp_curated_bucket\tgcp_curated_bucket_size\tteam_name\tn_samples\tn_subjects_unique\tn_samples_unique\tn_samples_total\tn_brain_samples\tn_brain_regions\tn_brain_donors\tn_subjects_healthy_control\tn_subjects_idiopathic_pd\tn_subjects_alzheimers_disease\tn_subjects_frontotemporal_dementia\tn_subjects_corticobasal_syndrome\tn_subjects_dementia_with_lewy_bodies\tn_subjects_dopa_responsive_dystonia\tn_subjects_essential_tremor\tn_subjects_hemiparkinson_hemiatrophy_syndrome\tn_subjects_juvenile_autosomal_recessive_parkinsonism\tn_subjects_motor_neuron_disease_with_parkinsonism\tn_subjects_multiple_system_atrophy\tn_subjects_neuroleptic_induced_parkinsonism\tn_subjects_normal_pressure_hydrocephalus\tn_subjects_progressive_supranuclear_palsy\tn_subjects_psychogenic_parkinsonism\tn_subjects_vascular_parkinsonism\tn_subjects_no_pd_nor_other_neurological_disorder\tn_subjects_spinocerebellar_ataxia_sca\tn_subjects_prodromal_non_motor_pd\tn_subjects_prodromal_motor_pd\tn_subjects_crohns_disease\tn_subjects_crohns_disease_remission\tn_subjects_other_neurological_disorder\tn_subjects_other_non_neurological_disease_or_condition\tcondition_counts" > "$output_file"
 fi
 
 unique_teams=""
@@ -303,31 +303,56 @@ while IFS= read -r slug; do
             | tr -d '[:space:]')
     fi
 
-    # Count subjects from SUBJECT table using whichever ID column exists
-    echo "Getting # of subjects from SUBJECT table..."
-    if echo "$collection_tables" | grep -qi "${team_name}_subject"; then
-        subject_id_col=$(dnastack collections query -c "$slug" \
-            "SELECT column_name FROM collections.information_schema.columns
-            WHERE table_schema = '$underscored_slug'
-              AND table_name = '${team_name}_subject'
-              AND (column_name = 'asap_subject_id' OR column_name = 'asap_mouse_id' OR column_name = 'asap_cell_id')
-            LIMIT 1" \
-            -o csv | tail -n +2 | tr -d '[:space:],"')
-        if [[ -n "$subject_id_col" ]]; then
-            subject_count=$(query_collection "$slug" \
-                "SELECT COUNT($subject_id_col) FROM \"collections\".\"$underscored_slug\".\"${team_name}_subject\"" \
+    # Sample-table-based unique + total counts. "Unique" deduplicates by
+    # subject/sample ID; "total" is the raw row count, which captures
+    # replicates of the same sample (same sample_id, multiple rows).
+    # The subject ID column in SAMPLE varies by organism: asap_subject_id
+    # (human), asap_mouse_id (mouse), asap_cell_id (cell-line). Some older
+    # tables only have the generic subject_id. Probe to find the right one.
+    # Cohorts don't have their own SAMPLE table — set NA for those.
+    n_subjects_unique="NA"
+    n_samples_unique="NA"
+    n_samples_total="NA"
+    if [[ "${parts[1]:-}" != "cohort" ]] && echo "$collection_tables" | grep -qi "${team_name}_sample"; then
+        echo "Getting unique + total counts from SAMPLE table..."
+
+        # Probe which subject-ID column exists in the SAMPLE table
+        sample_subject_col=""
+        for _cand in asap_subject_id asap_mouse_id asap_cell_id subject_id; do
+            if dnastack collections query -c "$slug" \
+                "SELECT column_name FROM collections.information_schema.columns
+                 WHERE table_schema = '$underscored_slug'
+                   AND table_name = '${team_name}_sample'
+                   AND column_name = '${_cand}'
+                 LIMIT 1" \
+                -o csv 2>/dev/null | tail -n +2 | grep -q "$_cand"; then
+                sample_subject_col="$_cand"
+                break
+            fi
+        done
+
+        if [[ -n "$sample_subject_col" ]]; then
+            n_subjects_unique=$(query_collection "$slug" \
+                "SELECT COUNT(DISTINCT $sample_subject_col) FROM \"collections\".\"$underscored_slug\".\"${team_name}_sample\" WHERE $sample_subject_col IS NOT NULL" \
                 | tr -d '[:space:]')
         else
-            echo "  No recognized subject ID column found in ${team_name}_subject, falling back to SAMPLE table" >&2
-            subject_count=$(query_collection "$slug" \
-                "SELECT COUNT(DISTINCT subject_id) FROM \"collections\".\"$underscored_slug\".\"${team_name}_sample\"" \
-                | tr -d '[:space:]')
+            echo "  [WARN] No subject ID column found in ${team_name}_sample; leaving n_subjects_unique as NA"
         fi
-    else
-        echo "  No SUBJECT table found, falling back to SAMPLE table" >&2
-        subject_count=$(query_collection "$slug" \
-            "SELECT COUNT(DISTINCT subject_id) FROM \"collections\".\"$underscored_slug\".\"${team_name}_sample\"" \
+
+        # asap_sample_id is CDE-required and assumed present in SAMPLE
+        # (matches the existing fallback used elsewhere in this script)
+        n_samples_unique=$(query_collection "$slug" \
+            "SELECT COUNT(DISTINCT asap_sample_id) FROM \"collections\".\"$underscored_slug\".\"${team_name}_sample\" WHERE asap_sample_id IS NOT NULL" \
             | tr -d '[:space:]')
+        n_samples_total=$(query_collection "$slug" \
+            "SELECT COUNT(*) FROM \"collections\".\"$underscored_slug\".\"${team_name}_sample\"" \
+            | tr -d '[:space:]')
+
+        # Defensive: if any query returned an empty string, fall back to NA
+        [[ -z "$n_subjects_unique" ]] && n_subjects_unique="NA"
+        [[ -z "$n_samples_unique"  ]] && n_samples_unique="NA"
+        [[ -z "$n_samples_total"   ]] && n_samples_total="NA"
+        echo "  subject_col=${sample_subject_col:-none} unique subjects=$n_subjects_unique unique samples=$n_samples_unique total samples=$n_samples_total"
     fi
 
     # Collect subject IDs for global deduplication.
@@ -728,10 +753,11 @@ print(n)
     if [[ -n "${PREVIOUS_CRN_SUMMARY_TSV:-}" ]]; then
         printf "\n" >> "$output_file"
     fi
-    printf "%s\t%s\t%s\t%s\t%s\t%s\t%s\t%s\t%s\t%s\t%s\t" \
+    printf "%s\t%s\t%s\t%s\t%s\t%s\t%s\t%s\t%s\t%s\t%s\t%s\t%s\t" \
         "$slug" "$gcp_raw_bucket" "$gcp_raw_bucket_size" \
         "$gcp_prod_bucket" "$gcp_prod_bucket_size" \
-        "$team_name" "$sample_count" "$subject_count" \
+        "$team_name" "$sample_count" \
+        "$n_subjects_unique" "$n_samples_unique" "$n_samples_total" \
         "$brain_sample_count" "$brain_region_count" "$brain_donor_count" >> "$output_file"
     printf "%s\t%s\n" "$primary_diagnosis_counts" "$condition_counts" >> "$output_file"
 done <<< "$ALL_DATASETS_TO_PROCESS"
@@ -750,7 +776,7 @@ calculate_breakdown() {
     echo "Calculating the ${count_type} breakdown"
     awk -F'\t' -v count_type="$count_type" '
     NR==1 {
-        count_col_name = (count_type == "sample") ? "n_samples" : "n_subjects"
+        count_col_name = (count_type == "sample") ? "n_samples" : "n_subjects_unique"
         for (i=1; i<=NF; i++) {
             if ($i == count_col_name) count_col = i
             if ($i == "gcp_raw_bucket") bucket_col = i
@@ -950,8 +976,8 @@ awk -F'\t' -v n_human_unique="$n_human_unique" -v n_mouse_unique="$n_mouse_uniqu
             -v n_cell_unique="$n_cell_unique"   -v n_total_unique="$n_total_unique" '
 NR==1 {
     for (i=1; i<=NF; i++) {
-        if ($i == "n_subjects")     subj_col = i
-        if ($i == "gcp_raw_bucket") bucket_col = i
+        if ($i == "n_subjects_unique") subj_col = i
+        if ($i == "gcp_raw_bucket")    bucket_col = i
     }
     next
 }
@@ -1001,7 +1027,8 @@ echo "=== DISEASE CATEGORY (PRIMARY DIAGNOSIS) SUMMARY ==="
 awk -F'\t' '
 NR==1 {
     for (i=1; i<=NF; i++) {
-        if ($i ~ /^n_subjects_[a-z]/) dx_cols[i] = $i
+        # Exclude n_subjects_unique (it is a count column, not a diagnosis column)
+        if ($i ~ /^n_subjects_[a-z]/ && $i != "n_subjects_unique") dx_cols[i] = $i
         if ($i == "condition_counts") cond_col = i
     }
     next

--- a/util/crn_cloud_collection_summary
+++ b/util/crn_cloud_collection_summary
@@ -91,7 +91,7 @@ get_bucket_from_slug() {
     echo "$bucket"
 }
 
-# From ASAP_CDE: https://docs.google.com/spreadsheets/d/1c0z5KvRELdT2AtQAH2Dus8kwAyyLrR0CROhKOjpU4Vc/edit?gid=43504703#gid=43504703
+# From ASAP_CDE v4.5: https://docs.google.com/spreadsheets/d/1c0z5KvRELdT2AtQAH2Dus8kwAyyLrR0CROhKOjpU4Vc/edit?gid=1821771235#gid=1821771235
 # Fixed ordered list of known primary_diagnosis values (display name -> column name).
 DIAGNOSIS_COLS=(
     "Healthy Control"

--- a/util/generate_dataset_summary_table
+++ b/util/generate_dataset_summary_table
@@ -11,7 +11,7 @@ Usage:
         <subject_diagnosis_membership_tsv> \
         [<sample_region_membership_tsv>]
 
-If the 5th argument is omitted, the script auto-discovers it by replacing
+If <sample_region_membership_tsv> is omitted, the script auto-discovers it by replacing
 "subject_dataset_membership" with "sample_region_dataset_membership" in the
 3rd argument's filename and using that path if it exists.
 

--- a/util/generate_dataset_summary_table
+++ b/util/generate_dataset_summary_table
@@ -1,13 +1,19 @@
 #!/usr/bin/env python3
 """
-Generate a pivot table of unique subject/sample counts by organism x tissue type x assay.
+Generate pivot tables of unique subject/sample counts by organism x tissue type x assay,
+and a long-format dataset-region breakdown.
 
 Usage:
     python3 generate_dataset_summary_table \
         <summary_tsv> \
         <subject_membership_tsv> \
         <sample_membership_tsv> \
-        <subject_diagnosis_membership_tsv>
+        <subject_diagnosis_membership_tsv> \
+        [<sample_region_membership_tsv>]
+
+If the 5th argument is omitted, the script auto-discovers it by replacing
+"subject_dataset_membership" with "sample_region_dataset_membership" in the
+3rd argument's filename and using that path if it exists.
 
 Works with output from either:
   - crn_cloud_collection_summary (production datasets in Releases)
@@ -79,6 +85,14 @@ def main():
     subj_mem_path   = sys.argv[2]
     sample_mem_path = sys.argv[3]
     diag_mem_path   = sys.argv[4]
+    # 5th arg is optional; auto-discover from the subject_membership path if omitted.
+    if len(sys.argv) >= 6 and sys.argv[5]:
+        region_mem_path = sys.argv[5]
+    else:
+        candidate = subj_mem_path.replace(
+            "subject_dataset_membership", "sample_region_dataset_membership"
+        )
+        region_mem_path = candidate if os.path.exists(candidate) else None
 
     print("Loading files...")
     crn_df    = pd.read_csv(tsv_path, sep="\t")
@@ -232,6 +246,46 @@ def main():
             row_vals = [diag_lookup.get((s, assay_), "") for o, s in COL_KEYS if o == "Human"]
             f.write(assay_ + "\t" + "\t".join(v.replace("\n", " / ") for v in row_vals) + "\n")
     print(f"Saved diagnosis table to {out_diag_tsv}")
+
+    # ---------------------------------------------------------------------------
+    # Dataset-region table — one row per (dataset, region_level_1, region_level_2)
+    # with distinct subject and sample counts. Long format, not pivoted, so it's
+    # easy to filter and re-pivot downstream.
+    # ---------------------------------------------------------------------------
+    if region_mem_path:
+        print("\nBuilding dataset-region table...")
+        region_df = pd.read_csv(region_mem_path, sep="\t", dtype=str).fillna("")
+        # Exclude cohort slugs (cohorts aggregate across teams — match the other tables)
+        region_df = region_df[~region_df["publisher_slug"].str.contains("cohort", na=False)].copy()
+        print(f"  rows loaded: {len(region_df)}")
+
+        if region_df.empty:
+            print("  (no rows in region membership file — skipping)")
+        else:
+            # Strip prod- prefix for the "dataset" display column
+            region_df["dataset"] = region_df["publisher_slug"].str.replace(r"^prod-", "", regex=True)
+
+            # Aggregate: distinct subjects and samples per (dataset, rl1, rl2)
+            grouped = (region_df
+                       .groupby(["dataset", "region_level_1", "region_level_2"], dropna=False)
+                       .agg(subject_count=("subject_id",
+                                           lambda s: s[s.astype(bool)].nunique()),
+                            sample_count=("asap_sample_id",
+                                          lambda s: s[s.astype(bool)].nunique()))
+                       .reset_index()
+                       .sort_values(["dataset", "region_level_1", "region_level_2"])
+                       .reset_index(drop=True))
+
+            out_region_tsv = f"dataset_region_table.{date_str}.tsv"
+            grouped.to_csv(out_region_tsv, sep="\t", index=False)
+
+            print(f"\n{'='*100}")
+            print("DATASET-REGION TABLE  (one row per dataset × region; distinct subjects / samples)")
+            print(f"{'='*100}")
+            print(grouped.to_string(index=False))
+            print(f"\nSaved dataset-region table to {out_region_tsv}")
+    else:
+        print("\nNo sample_region_dataset_membership file found — skipping dataset-region table.")
 
 
 if __name__ == "__main__":

--- a/util/generate_dataset_summary_table
+++ b/util/generate_dataset_summary_table
@@ -13,7 +13,7 @@ Usage:
 
 If <sample_region_membership_tsv> is omitted, the script auto-discovers it by replacing
 "subject_dataset_membership" with "sample_region_dataset_membership" in the
-3rd argument's filename and using that path if it exists.
+<sample_membership_tsv>'s filename and using that path if it exists.
 
 Works with output from either:
   - crn_cloud_collection_summary (production datasets in Releases)

--- a/util/internal_qc_dataset_collection_summary
+++ b/util/internal_qc_dataset_collection_summary
@@ -17,6 +17,7 @@ cat << EOF
   - internal_qc_dataset_collection_summary.sample_dataset_membership.<date_str>.tsv
   - internal_qc_dataset_collection_summary.brain_donor_dataset_membership.<date_str>.tsv
   - internal_qc_dataset_collection_summary.subject_diagnosis_membership.<date_str>.tsv
+  - internal_qc_dataset_collection_summary.sample_region_dataset_membership.<date_str>.tsv (one row per sample with brain region info)
 
   Usage: $0 [OPTIONS]
 
@@ -48,10 +49,12 @@ subject_membership_file="internal_qc_dataset_collection_summary.subject_dataset_
 sample_membership_file="internal_qc_dataset_collection_summary.sample_dataset_membership.$date_str.tsv"
 brain_donor_membership_file="internal_qc_dataset_collection_summary.brain_donor_dataset_membership.$date_str.tsv"
 subject_diagnosis_membership_file="internal_qc_dataset_collection_summary.subject_diagnosis_membership.$date_str.tsv"
+sample_region_membership_file="internal_qc_dataset_collection_summary.sample_region_dataset_membership.$date_str.tsv"
 echo -e "subject_id\tpublisher_slug"      > "$subject_membership_file"
 echo -e "asap_sample_id\tpublisher_slug"  > "$sample_membership_file"
 echo -e "asap_subject_id\tpublisher_slug" > "$brain_donor_membership_file"
 echo -e "asap_subject_id\tprimary_diagnosis\tpublisher_slug" > "$subject_diagnosis_membership_file"
+echo -e "subject_id\tasap_sample_id\tregion_level_1\tregion_level_2\tpublisher_slug" > "$sample_region_membership_file"
 
 # Normalize a CSV so that multi-line quoted fields are collapsed to a single line.
 # Embedded newlines (CR/LF) inside quoted fields are replaced with spaces.
@@ -229,6 +232,86 @@ while IFS= read -r bucket; do
         get_unique_column_values "$sample_csv" "sample_id" \
             | awk -v slug="$publisher_slug" 'NF { print $0 "\t" slug }' \
             >> "$sample_membership_file"
+
+        # Sample region membership: one row per sample with brain region info.
+        # Source priority:
+        #   1. SAMPLE.region_level_1 / region_level_2 (CDE 4.x)
+        #   2. PMDBS.brain_region (legacy CDE; populates region_level_1 only)
+        # Samples with both levels empty after both lookups are skipped.
+        pmdbs_csv_for_region=""
+        if [[ -n "$sample_csv_dir" ]] && gcloud storage ls "$sample_csv_dir/PMDBS.csv" &>/dev/null; then
+            pmdbs_csv_for_region=$(gcloud storage cat "$sample_csv_dir/PMDBS.csv" | normalize_csv)
+        fi
+        region_rows_written=$(python3 -c '
+import csv, io, sys
+slug = sys.argv[1]; out = sys.argv[2]
+sample_text = sys.argv[3]; pmdbs_text = sys.argv[4]
+
+NA = {"", "na", "n/a", "none", "null", "nan"}
+def clean(v):
+    s = (v or "").strip().strip("\"")
+    return "" if s.lower() in NA else s
+
+def read_csv(text):
+    if not text: return [], {}
+    reader = csv.DictReader(io.StringIO(text))
+    fields = reader.fieldnames or []
+    norm = {f.strip().strip("\"").lstrip("﻿"): f for f in fields}
+    return list(reader), norm
+
+# SAMPLE pass: sample_id -> (subject_id, rl1, rl2)
+sample_rows, sn = read_csv(sample_text)
+sid_key  = sn.get("sample_id")
+subj_key = sn.get("subject_id")
+rl1_key  = sn.get("region_level_1")
+rl2_key  = sn.get("region_level_2")
+sample_map = {}
+if sid_key:
+    for r in sample_rows:
+        sid     = clean(r.get(sid_key))
+        subj_id = clean(r.get(subj_key)) if subj_key else ""
+        rl1     = clean(r.get(rl1_key)) if rl1_key else ""
+        rl2     = clean(r.get(rl2_key)) if rl2_key else ""
+        if sid:
+            sample_map[sid] = (subj_id, rl1, rl2)
+
+# PMDBS fallback: only fills where SAMPLE had no region info.
+# PMDBS may also carry region_level_1/2 in newer CDE — prefer those over brain_region.
+pmdbs_rows, pn = read_csv(pmdbs_text)
+psid_key  = pn.get("sample_id")
+psubj_key = pn.get("subject_id")
+br_key    = pn.get("brain_region")
+prl1_key  = pn.get("region_level_1")
+prl2_key  = pn.get("region_level_2")
+if psid_key and (br_key or prl1_key or prl2_key):
+    for r in pmdbs_rows:
+        sid = clean(r.get(psid_key))
+        if not sid:
+            continue
+        rl1 = clean(r.get(prl1_key)) if prl1_key else ""
+        rl2 = clean(r.get(prl2_key)) if prl2_key else ""
+        if not rl1 and br_key:
+            rl1 = clean(r.get(br_key))
+        if not rl1 and not rl2:
+            continue
+        ex_subj, ex_rl1, ex_rl2 = sample_map.get(sid, ("", "", ""))
+        if not ex_rl1 and not ex_rl2:
+            subj_id = ex_subj or (clean(r.get(psubj_key)) if psubj_key else "")
+            sample_map[sid] = (subj_id, rl1, rl2)
+
+# Emit rows where at least one region is populated
+n = 0
+with open(out, "a") as fh:
+    for sid, (subj_id, rl1, rl2) in sample_map.items():
+        if not rl1 and not rl2:
+            continue
+        cleaned = [v.replace("\t", " ").replace("\n", " ").replace("\r", " ")
+                   for v in (subj_id, sid, rl1, rl2, slug)]
+        fh.write("\t".join(cleaned) + "\n")
+        n += 1
+print(n)
+' "$publisher_slug" "$sample_region_membership_file" "$sample_csv" "$pmdbs_csv_for_region" 2>/dev/null || true)
+        echo "  Wrote ${region_rows_written:-0} sample-region rows"
 
         # Brain sample / donor logic mirrors CRN cloud script:
         #   1. Brain samples (independent of CLINPATH):
@@ -741,3 +824,4 @@ echo "Saved subject membership to [$(pwd)/$subject_membership_file]"
 echo "Saved sample membership to [$(pwd)/$sample_membership_file]"
 echo "Saved brain donor membership to [$(pwd)/$brain_donor_membership_file]"
 echo "Saved subject diagnosis membership to [$(pwd)/$subject_diagnosis_membership_file]"
+echo "Saved sample region membership to [$(pwd)/$sample_region_membership_file]"

--- a/util/internal_qc_dataset_collection_summary
+++ b/util/internal_qc_dataset_collection_summary
@@ -42,7 +42,7 @@ done
 
 date_str=$(date +"%Y-%m-%d")
 output_file="internal_qc_dataset_collection_summary.$date_str.tsv"
-echo -e "publisher_slug\tteam\tgcp_raw_bucket\tgcp_raw_bucket_size\tsample_count\tsubject_count" > "$output_file"
+echo -e "publisher_slug\tteam\tgcp_raw_bucket\tgcp_raw_bucket_size\tn_subjects_unique\tn_samples_unique\tn_samples_total" > "$output_file"
 
 # Membership files (match CRN script's headers so the Python summary tool can read both)
 subject_membership_file="internal_qc_dataset_collection_summary.subject_dataset_membership.$date_str.tsv"
@@ -102,6 +102,44 @@ get_unique_column_count() {
             if (v ~ /[^[:space:]]/) print v
         }
     ' <<< "$csv_content" | sort -u | wc -l | tr -d '[:space:]'
+}
+
+# Like get_unique_column_count but without the dedup step — counts every
+# non-empty occurrence of the column value. Used for "_total" counts so
+# replicate rows with the same sample_id (or subject_id) each contribute.
+get_total_column_count() {
+    local csv_content="$1"
+    local column_name="$2"
+
+    local col_no
+    col_no=$(awk -F',' -v col="$column_name" '
+        NR==1 {
+            for (i=1; i<=NF; i++) {
+                f=$i; gsub(/^"|"$|\r/, "", f)
+                if (f == col) { print i; exit }
+            }
+            exit
+        }
+    ' <<< "$csv_content")
+
+    if [[ -z "$col_no" ]]; then
+        echo ""
+        return 0
+    fi
+
+    awk -F',' -v c="$col_no" '
+        NR>1 {
+            v=$c; gsub(/^"|"$|\r/, "", v)
+            if (v ~ /[^[:space:]]/) print v
+        }
+    ' <<< "$csv_content" | wc -l | tr -d '[:space:]'
+}
+
+# Count raw data rows in a CSV (skipping the header). Used for n_samples_total
+# = total row count of SAMPLE.csv, which captures replicates of the same sample.
+get_total_row_count() {
+    local csv_content="$1"
+    awk 'NR>1 && /[^[:space:]]/ { n++ } END { print n+0 }' <<< "$csv_content"
 }
 
 # Extract distinct, non-empty values from a named column in a CSV string.
@@ -180,8 +218,9 @@ while IFS= read -r bucket; do
     publisher_slug="prod-${bucket#asap-raw-}"
 
     echo "Trying to get # of samples and subjects"
-    sample_count="NA"
-    subject_count="NA"
+    n_subjects_unique="NA"
+    n_samples_unique="NA"
+    n_samples_total="NA"
     sample_csv=""
     sample_csv_dir=""
     # First try: metadata/release/SAMPLE.csv
@@ -189,8 +228,6 @@ while IFS= read -r bucket; do
         echo "  Found metadata/release/SAMPLE.csv"
         sample_csv=$(gcloud storage cat "$gcp_raw_bucket/metadata/release/SAMPLE.csv" | normalize_csv)
         sample_csv_dir="$gcp_raw_bucket/metadata/release"
-        sample_count=$(get_unique_column_count "$sample_csv" "sample_id")
-        subject_count=$(get_unique_column_count "$sample_csv" "subject_id")
     else
     # Second try: search metadata/ for any SAMPLE.csv
         echo "  metadata/release/SAMPLE.csv not found, searching metadata folder for SAMPLE.csv..."
@@ -200,11 +237,23 @@ while IFS= read -r bucket; do
             echo "  Found SAMPLE.csv at: $sample_csv_loc"
             sample_csv=$(gcloud storage cat "$sample_csv_loc" | normalize_csv)
             sample_csv_dir="${sample_csv_loc%/SAMPLE.csv}"
-            sample_count=$(get_unique_column_count "$sample_csv" "sample_id")
-            subject_count=$(get_unique_column_count "$sample_csv" "subject_id")
         else
             echo "  No SAMPLE.csv found in metadata/ path"
         fi
+    fi
+
+    # Unique + total counts from SAMPLE.csv. "Unique" deduplicates by sample_id /
+    # subject_id; n_samples_total is the raw row count of SAMPLE.csv, which
+    # captures replicate rows of the same sample.
+    if [[ -n "$sample_csv" ]]; then
+        n_subjects_unique=$(get_unique_column_count "$sample_csv" "subject_id")
+        n_samples_unique=$(get_unique_column_count "$sample_csv" "sample_id")
+        n_samples_total=$(get_total_row_count "$sample_csv")
+        # Defensive: if any helper returned an empty string, fall back to NA
+        [[ -z "$n_subjects_unique" ]] && n_subjects_unique="NA"
+        [[ -z "$n_samples_unique"  ]] && n_samples_unique="NA"
+        [[ -z "$n_samples_total"   ]] && n_samples_total="NA"
+        echo "  unique subjects=$n_subjects_unique unique samples=$n_samples_unique total samples=$n_samples_total"
     fi
 
     # Collect IDs for global deduplication (only when SAMPLE.csv was found)
@@ -548,7 +597,7 @@ print(n)
         gcp_raw_bucket_size=$(gcloud storage du -s "$gcp_raw_bucket" | grep -oE '^[0-9]+')
     fi
 
-    echo -e "${publisher_slug}\t${team}\t${gcp_raw_bucket}\t${gcp_raw_bucket_size}\t${sample_count}\t${subject_count}" >> "$output_file"
+    echo -e "${publisher_slug}\t${team}\t${gcp_raw_bucket}\t${gcp_raw_bucket_size}\t${n_subjects_unique}\t${n_samples_unique}\t${n_samples_total}" >> "$output_file"
 done <<< "$RAW_BUCKETS"
 
 # Clean up
@@ -561,7 +610,9 @@ calculate_breakdown() {
     echo "Calculating the ${count_type} breakdown"
     awk -F'\t' -v count_type="$count_type" '
     NR==1 {
-        count_col_name = count_type "_count"
+        # "sample"  -> n_samples_unique
+        # "subject" -> n_subjects_unique
+        count_col_name = (count_type == "sample") ? "n_samples_unique" : "n_subjects_unique"
         for (i=1; i<=NF; i++) {
             if ($i == count_col_name) count_col = i
             if ($i == "gcp_raw_bucket") bucket_col = i
@@ -789,8 +840,8 @@ awk -F'\t' -v n_human_unique="$n_human_unique" -v n_mouse_unique="$n_mouse_uniqu
             -v n_cell_unique="$n_cell_unique"   -v n_total_unique="$n_total_unique" '
 NR==1 {
     for (i=1; i<=NF; i++) {
-        if ($i == "subject_count")  subj_col = i
-        if ($i == "gcp_raw_bucket") bucket_col = i
+        if ($i == "n_subjects_unique") subj_col = i
+        if ($i == "gcp_raw_bucket")    bucket_col = i
     }
     next
 }


### PR DESCRIPTION
## Description

Adds a per-sample brain-region membership TSV and a `dataset × region` pivot to the CRN cloud / internal QC reporting scripts, and reworks the subject/sample count columns in both summary scripts so deduplicated vs. replicate-inclusive counts are explicit and consistent.

## Dependencies (Issues/PRs)

https://app.clickup.com/t/9014209604/BIOS-2257

## Type of Change

- [ ] Bug fix
- [x] New feature
- [x] Documentation

## Task Checklist

- [x] Documentation updated
- [x] Human reviewed any code produced or modified by AI

