### PR TITLE
Feature/raw bucket transfer latest only

### DIFF
--- a/util/common/bucket_validation_utils.py
+++ b/util/common/bucket_validation_utils.py
@@ -326,7 +326,10 @@ def validate_local_metadata_structure(
         if is_cohort:
             logging.info("Skipping original/ check for cohort dataset")
         else:
-            raise ValueError(f"metadata/original/ directory not found: {original_dir}")
+            raise ValueError(
+                f"metadata/original/ directory not found: {original_dir}. "
+                f"Restore it with: download_raw_bucket_metadata_to_local -d <dataset-id> -O -p"
+            )
     
     # CDE/ is not created for cohorts, only release/ metadata copies are made
     if is_cohort:

--- a/util/raw_bucket_prep/download_raw_bucket_metadata_to_local
+++ b/util/raw_bucket_prep/download_raw_bucket_metadata_to_local
@@ -86,8 +86,14 @@ def main(args):
     check_dataset_dir_exists(dataset_dir)
     validate_raw_bucket_structure(bucket_name)
     
-    # Detect bucket structure: initial submission vs post-QC
-    structure_type = detect_raw_bucket_structure(bucket_name)
+    # Detect initial submission vs post-QC structure. Cohorts don't have an initial structure.
+    is_cohort = dataset_name.startswith("cohort")
+    if is_cohort:
+        if args.original_only:
+            raise SystemExit("--original-only is not valid for cohort datasets: cohorts do not have a metadata/original/ directory.")
+        structure_type = "complete"
+    else:
+        structure_type = detect_raw_bucket_structure(bucket_name)
     
     # Initial submission: download from raw bucket metadata/ to local metadata/original/
     if structure_type == "initial":

--- a/util/raw_bucket_prep/download_raw_bucket_metadata_to_local
+++ b/util/raw_bucket_prep/download_raw_bucket_metadata_to_local
@@ -1,16 +1,29 @@
 #!/usr/bin/env python3
 
-# Download metadata submitted by contributors from the raw bucket to a local dataset
-# directory to prepare for QC.
-# Defaults to dry run unless -p flag is added!
+# Download metadata from the raw bucket to a local dataset directory for QC.
+#
+# This script has different behaviors depending on the structure of the raw bucket:
+# 1. Initial submission structure (only metadata/* with .CSVs): downloads to local
+#    <dataset_id>/metadata/original/
+# 2. Post-QC structure (after transfer_qc_metadata_to_raw_bucket has been run):
+#    downloads the entire metadata/ tree to local <dataset_id>/metadata/, as well
+#    as file_metadata/ and DOI/, unless --original-only is specified, in which case
+#    it only downloads metadata/original/. 
+#
 # Usage: python3 download_raw_bucket_metadata_to_local -d team-jakobsson-pmdbs-bulk-rnaseq
-# Use -V/--validate-only to just check the raw bucket structure/metadata and exit
-# (no download); this replaces the former standalone validate_raw_bucket_structure.py.
-# NOTE on assumptions made:
-# 1.   You have cloned asap-crn-cloud-dataset-metadata and its root is at the
-# ---- same level as wf-common
-# 2.   The raw bucket exists and has metadata in the metadata/ subdirectory
-# 3.   The local dataset directory exists (ideally created by initialization script)
+# 1. -p/--promote Defaults to dry run unless this flag is added to actually perform the download
+# 2. -V/--validate-only to just check the raw bucket structure/metadata and exit
+#    (no download); this replaces the former standalone validate_raw_bucket_structure.py.
+# 3. -O/--original-only to only download metadata/original/ (post-QC structure) 
+#    instead of the full metadata/ tree. This is for scenarios where you want to 
+#    re-download just the original metadata from the bucket without overwriting 
+#    the QC'd cde/ and release/ directories locally.
+
+# Assumptions made:
+# 1. You have cloned asap-crn-cloud-dataset-metadata and its root is at the
+#    same level as wf-common
+# 2. The raw bucket exists and has metadata .CSVs in the open metadata/* subdirectory
+# 3. The local dataset directory exists (created by asap-crn-cloud-dataset-metadata/scripts/intiate_dataset.py) 
 
 import argparse
 import logging
@@ -28,13 +41,12 @@ from bucket_validation_utils import (
     detect_raw_bucket_structure
 )
 
-
 logging.basicConfig(
     level=logging.INFO,
     format="%(asctime)s - %(levelname)s - %(message)s"
 )
  
-repo_root = Path(__file__).resolve().parents[1]
+repo_root = Path(__file__).resolve().parents[2]
 metadata_root = repo_root.parent / "asap-crn-cloud-dataset-metadata"
 
 
@@ -53,6 +65,7 @@ def main(args):
     
     bucket_name = f"gs://asap-raw-{dataset_id}"
     metadata_bucket = f"{bucket_name}/metadata"
+    original_metadata_bucket = f"{metadata_bucket}/original"
     file_metadata_bucket = f"{bucket_name}/file_metadata"
     doi_bucket = f"{bucket_name}/DOI"
 
@@ -76,8 +89,10 @@ def main(args):
     # Detect bucket structure: initial submission vs post-QC
     structure_type = detect_raw_bucket_structure(bucket_name)
     
-    # Initial submission: download from metadata/ directly to metadata/original/
+    # Initial submission: download from raw bucket metadata/ to local metadata/original/
     if structure_type == "initial":
+        if args.original_only:
+            logging.info("--original-only has no effect on initial submission structure; downloading to original/ anyway")
         
         # Warns if CORE tables missing, errors only if no files found.
         files_valid = check_original_metadata_files_in_bucket(bucket_name)
@@ -96,44 +111,56 @@ def main(args):
             dry_run=dry_run
         )
     
-    # Post QC-structure: will sync the entire metadata/ tree    
+    # Post QC-structure: will sync the entire metadata/ tree or metadata/original if --original-only specified    
     elif structure_type == "complete":
-        logging.info(f"Downloading metadata from [{metadata_bucket}] to [{metadata_dir}]")
         
-        metadata_dir.mkdir(parents=True, exist_ok=True)
-        
-        gsync(
-            source_path=metadata_bucket, 
-            destination_path=metadata_dir, 
-            dry_run=dry_run
-        )
+        if args.original_only:
+            original_dir.mkdir(parents=True, exist_ok=True)
+            logging.info(f"Downloading original metadata only: [{original_metadata_bucket}] to {original_dir}")
+            
+            gsync(
+                source_path=original_metadata_bucket, 
+                destination_path=original_dir, 
+                dry_run=dry_run
+            )
+            
+        else:
+            metadata_dir.mkdir(parents=True, exist_ok=True)
+            logging.info(f"Downloading metadata from [{metadata_bucket}] to [{metadata_dir}]")
+            
+            gsync(
+                source_path=metadata_bucket, 
+                destination_path=metadata_dir, 
+                dry_run=dry_run
+            )
         
     # Optional: also sync the file_metadata/ and DOI/ directories if they exist
-    try:
-        list_dirs(file_metadata_bucket) # Check if directory exists
-        file_metadata_dir.mkdir(parents=True, exist_ok=True)
-        logging.info(f"Downloading file_metadata/ from [{file_metadata_bucket}] to {file_metadata_dir}")
+    if not args.original_only:
+        try:
+            list_dirs(file_metadata_bucket) # Check if directory exists
+            file_metadata_dir.mkdir(parents=True, exist_ok=True)
+            logging.info(f"Downloading file_metadata/ from [{file_metadata_bucket}] to {file_metadata_dir}")
        
-        gsync(
-            source_path=file_metadata_bucket, 
-            destination_path=file_metadata_dir, 
-            dry_run=dry_run
-        )
-    except subprocess.CalledProcessError:
-        pass # Directory does not exist, skip w/o log as not expected for initial submission
+            gsync(
+                source_path=file_metadata_bucket, 
+                destination_path=file_metadata_dir, 
+                dry_run=dry_run
+            )
+        except subprocess.CalledProcessError:
+            pass # Directory does not exist, skip w/o log as not expected for initial submission
     
-    try:
-        list_dirs(doi_bucket)
-        doi_dir.mkdir(parents=True, exist_ok=True)
-        logging.info(f"Downloading DOI/ from [{doi_bucket}] to {doi_dir}")
+        try:
+            list_dirs(doi_bucket)
+            doi_dir.mkdir(parents=True, exist_ok=True)
+            logging.info(f"Downloading DOI/ from [{doi_bucket}] to {doi_dir}")
        
-        gsync(
-            source_path=doi_bucket, 
-            destination_path=doi_dir, 
-            dry_run=dry_run
-        )
-    except subprocess.CalledProcessError:
-        pass
+            gsync(
+                source_path=doi_bucket, 
+                destination_path=doi_dir, 
+                dry_run=dry_run
+            )
+        except subprocess.CalledProcessError:
+            pass
 
 
 if __name__ == "__main__":
@@ -163,6 +190,14 @@ if __name__ == "__main__":
         required=False,
         help="Only validate the raw bucket structure and metadata, then exit (no download)."
     )
+    parser.add_argument(
+        "-O",
+        "--original-only",
+        action="store_true",
+        required=False,
+        help="Only download metadata/original/ from the bucket (post-QC structure only)"
+    )
+    
 
     args = parser.parse_args()
 

--- a/util/raw_bucket_prep/transfer_qc_metadata_to_raw_bucket
+++ b/util/raw_bucket_prep/transfer_qc_metadata_to_raw_bucket
@@ -11,7 +11,7 @@
 # after this transfer and must be manually deleted if they are no longer relevant.
 #
 # Usage: python3 transfer_qc_metadata_to_raw_bucket -d team-jakobsson-pmdbs-bulk-rnaseq -v v4.0.1 -p
-# 1. -p/--promote Defaults to dry run unless this flag is added to actually persform the upload
+# 1. -p/--promote Defaults to dry run unless this flag is added to actually perform the upload
 # 2. -v/--release_version of the dataset indicating QC is complete for the given version
 
 # Assumptions made:

--- a/util/raw_bucket_prep/transfer_qc_metadata_to_raw_bucket
+++ b/util/raw_bucket_prep/transfer_qc_metadata_to_raw_bucket
@@ -41,7 +41,7 @@ logging.basicConfig(
 	format="%(asctime)s - %(levelname)s - %(message)s"
 )
 
-repo_root = Path(__file__).resolve().parents[1]
+repo_root = Path(__file__).resolve().parents[2]
 metadata_root = repo_root.parent / "asap-crn-cloud-dataset-metadata"
 
 

--- a/util/raw_bucket_prep/transfer_qc_metadata_to_raw_bucket
+++ b/util/raw_bucket_prep/transfer_qc_metadata_to_raw_bucket
@@ -1,25 +1,24 @@
 #!/usr/bin/env python3
 
 # Transfer locally saved QC'd metadata to the raw Google bucket
-# Usage:
-#   Single dataset:
-#     python3 transfer_qc_metadata_to_raw_bucket -d team-jakobsson-pmdbs-bulk-rnaseq -v v4.0.1 -p
 #
-# Batch processing (datasets.csv field 1 is is dataset id, field 2 is release version, no header):
-#     while IFS=, read -r team dataset; do
-#         python3 transfer_qc_metadata_to_raw_bucket -d "$dataset_id" -p
-#     done < datasets.csv
+# This script performs an rysnc of a dataset's local metadata/, file_metadata, and DOI/
+# directories to the raw bucket following QC. It requires that the local 
+# metadata/original/ as well as a specified post-QC release/{release_version} directory 
+# exists before uploading. Note that this rysnc will replace existing files, but will
+# not delete any files in the bucket that are not present locally. This means that
+# loose files in metadata/* from the initial submission will remain in the bucket
+# after this transfer and must be manually deleted if they are no longer relevant.
 #
-# Defaults to dry run unless -p flag is added!
-# 
-# NOTE on assumptions made:
-# 1.   You have cloned asap-crn-cloud-dataset-metadata and its root is at the
-# ---- same level as wf-common
-# 2.   The metadata/ directory of the target dataset exists locally and contains
-# ---- the finalized QC'd metadata structure (original/, cde/, and 
-# ---- release/{release_version} dirs)
-# 3.   The file_metadata/ directory exists locally and is populated with the files
-# ---- artifacts.csv, raw_files.csv, and curated_files.csv
+# Usage: python3 transfer_qc_metadata_to_raw_bucket -d team-jakobsson-pmdbs-bulk-rnaseq -v v4.0.1 -p
+# 1. -p/--promote Defaults to dry run unless this flag is added to actually persform the upload
+# 2. -v/--release_version of the dataset indicating QC is complete for the given version
+
+# Assumptions made:
+# 1. You have cloned asap-crn-cloud-dataset-metadata and its root is at the same level as wf-common
+# 2. The metadata/ directory of the target dataset exists locally and contains
+#    the post-QC metadata structure: original/, cde/, release/{release_version}, latest/
+# 3. The file_metadata/ directory exists locally and is populated
 
 import argparse
 import logging
@@ -31,10 +30,8 @@ from gcloud_ops import gsync, strip_team_prefix, gcopy
 from bucket_validation_utils import (
     FILE_METADATA_FILES,
     check_bucket_exists,
-    check_original_metadata_exists_locally,
     validate_local_metadata_structure
 )
-
 
 logging.basicConfig(
 	level=logging.INFO,
@@ -70,21 +67,13 @@ def main(args):
     validate_local_metadata_structure(metadata_dir, is_cohort=is_cohort, release_version=release_version)
 
     # Transfers entire metadata/ directory
-    if metadata_dir.exists():
-        logging.info(f"Transferring local metadata directory to [{metadata_bucket}]")
-        
-        # Early exit if original metadata is missing: implies incomplete QC
-        if not is_cohort and not check_original_metadata_exists_locally(metadata_dir):
-            raise ValueError(f"original/ directory is missing in local metadata dir: {metadata_dir}")
-        
-        gsync(
-            source_path=str(metadata_dir),
-            destination_path=metadata_bucket,
-            dry_run=dry_run
-        )
-    else:
-        raise ValueError(f"Local metadata directory not found: {metadata_dir}")
-
+    logging.info(f"Transferring local metadata directory to [{metadata_bucket}]")
+    gsync(
+        source_path=str(metadata_dir),
+        destination_path=metadata_bucket,
+        dry_run=dry_run
+    )
+    
     # Transfer file_metadata/ files
     if file_metadata_dir.exists():
         logging.info(f"Transferring selected local file_metadata/ files to [{file_metadata_bucket}]")


### PR DESCRIPTION
## Description

This PR handles a couple different issues:

1. Since we are tracking `latest/` only, it means that `metadata/original/` may not exist locally. However, running `download_raw_bucket_metadata_to_local` to populate may inadvertently overwrite local working copies of `metadata/release/` or `latest/`. This adds the `-O/--original-only` flag to the download script to download `original/` only
2. There was an interaction with cohort datasets that inappropriately downloaded cohort `metadata/` from the raw bucket into `metadata/original` locally that has been fixed.

It also improves the top level doc and removes a dead-end/redundant check in the transfer script.

What this **DOES NOT** do:
Originally I was also going to add a clean up step after the initial local -> raw bucket transfer, to remove the loose .csv files in metadata/* that now exist in `metadata/original/` post-QC. However, it seemed that this was risky so I'm keeping this as a manual check and delete step for the time being.

## Dependencies (Issues/PRs)

[ClickUp Issue](https://app.clickup.com/t/9014209604/BIOS-236)


## Type of Change

- [x] Bug fix
- [x] New feature
- [ ] Documentation

## Task Checklist

- [x] Documentation updated
- [x] Human reviewed any code produced or modified by AI

