### PR TITLE
Pre-QC, add alternative metadata delimiters 

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,3 +4,13 @@ Workflows, tasks, utility scripts, and docker images reused across harmonized AS
 - Common tasks that may be reused within or between workflows are defined in [the wdl directory](wdl).
 - Common utility scripts that may be reused are defined in [the util directory](util).
 - Common docker images used in workflows are defined in [the docker directory](docker).
+
+## Python requirements
+
+- `pyproject.toml` — declares the minimum Python version (`>=3.10`). Required by the union type syntax (`X | Y`) used in utility scripts.
+- `requirements.txt` — lists third-party pip dependencies for the utility scripts.
+
+Install dependencies with:
+```bash
+pip install -r requirements.txt
+```

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,0 +1,3 @@
+[project]
+name = "wf-common"
+requires-python = ">=3.10"

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,5 @@
+# crn_utils — install locally: pip install -e ~/crn-utils
+gspread==6.2.1
+packaging==26.2
+pandas==3.0.3
+protobuf==7.35.1

--- a/util/common/file_utils.py
+++ b/util/common/file_utils.py
@@ -4,7 +4,6 @@
 import csv
 import os
 import re
-import statistics
 from pathlib import Path
 
 
@@ -58,25 +57,30 @@ def detect_csv_delimiter(file_path: Path, num_lines: int = _DELIMITER_DETECTION_
     header_line = lines[0]
     candidate_lines = lines[:max(2, min(len(lines), num_lines))]
 
+    def _field_count(line: str, delim: str) -> int:
+        try:
+            return len(next(csv.reader([line], delimiter=delim)))
+        except Exception:
+            return 0
+
+    header_field_counts = {d: _field_count(header_line, d) for d in _SUPPORTED_DELIMITERS}
+    data_lines = candidate_lines[1:]
+
     scores = {}
     for delim in _SUPPORTED_DELIMITERS:
         if delim not in header_line:
             scores[delim] = -1.0
             continue
-        counts = [line.count(delim) for line in candidate_lines]
-        if not counts:
+        n_header_fields = header_field_counts[delim]
+        if n_header_fields <= 1:
             scores[delim] = -1.0
             continue
-        median_count = statistics.median(counts)
-        if median_count <= 0:
-            scores[delim] = -1.0
+        if not data_lines:
+            scores[delim] = float(n_header_fields)
             continue
-        consistency = sum(1 for c in counts if c == median_count) / float(len(counts))
-        est_cols = header_line.count(delim) + 1
-        if est_cols <= 1:
-            scores[delim] = -1.0
-            continue
-        scores[delim] = (consistency * 100.0) + float(median_count)
+        field_match = sum(1 for line in data_lines if _field_count(line, delim) == n_header_fields)
+        consistency = field_match / len(data_lines)
+        scores[delim] = (consistency * 100.0) + float(n_header_fields)
 
     best = max(scores, key=scores.get)
     return best if scores[best] >= 0 else ","

--- a/util/common/file_utils.py
+++ b/util/common/file_utils.py
@@ -1,10 +1,85 @@
 #!/usr/bin/env python3
 """General-purpose functions to parse file properties (e.g. size, extension)."""
 
+import csv
 import os
 import re
+import statistics
 from pathlib import Path
-import csv
+
+
+_SUPPORTED_DELIMITERS = [",", ";", "\t", "|"]
+_ENCODINGS_TO_TRY = ("utf-8-sig", "utf-8", "cp1252", "latin-1")
+_DELIMITER_DETECTION_LINES = 50
+
+
+def detect_csv_delimiter(file_path: Path, num_lines: int = _DELIMITER_DETECTION_LINES) -> str:
+    """
+    Detect the delimiter used in a CSV-like file using line-level statistics.
+
+    Tries comma, semicolon, tab, and pipe. Scores each candidate by presence in
+    the header, median count per line, and consistency across lines. Falls back
+    to comma if no delimiter can be confidently identified.
+
+    Adapted from DelimiterHandler.detect_delimiter() in crn-meta-validate, with
+    all Streamlit dependencies removed.
+
+    Parameters
+    ----------
+    file_path : Path
+        Path to the file to inspect.
+    num_lines : int
+        Maximum number of non-empty lines to evaluate. Default is 50.
+
+    Returns
+    -------
+    str
+        Detected delimiter character. Defaults to ',' if detection is inconclusive.
+    """
+    try:
+        raw = file_path.read_bytes()
+    except Exception:
+        return ","
+
+    decoded = None
+    for enc in _ENCODINGS_TO_TRY:
+        try:
+            decoded = raw.decode(enc)
+            break
+        except UnicodeDecodeError:
+            continue
+    if decoded is None:
+        decoded = raw.decode("utf-8", errors="ignore")
+
+    lines = [line for line in decoded.splitlines() if line.strip()]
+    if not lines:
+        return ","
+
+    header_line = lines[0]
+    candidate_lines = lines[:max(2, min(len(lines), num_lines))]
+
+    scores = {}
+    for delim in _SUPPORTED_DELIMITERS:
+        if delim not in header_line:
+            scores[delim] = -1.0
+            continue
+        counts = [line.count(delim) for line in candidate_lines]
+        if not counts:
+            scores[delim] = -1.0
+            continue
+        median_count = statistics.median(counts)
+        if median_count <= 0:
+            scores[delim] = -1.0
+            continue
+        consistency = sum(1 for c in counts if c == median_count) / float(len(counts))
+        est_cols = header_line.count(delim) + 1
+        if est_cols <= 1:
+            scores[delim] = -1.0
+            continue
+        scores[delim] = (consistency * 100.0) + float(median_count)
+
+    best = max(scores, key=scores.get)
+    return best if scores[best] >= 0 else ","
 
 
 def parse_file_size_to_bytes(size_str: str) -> int:
@@ -68,6 +143,8 @@ def check_csv_rows(csv_path: Path, min_rows: int = 2) -> dict:
     """
     Check whether a CSV file has at least `min_rows` rows (header + data).
 
+    The delimiter is auto-detected via `detect_csv_delimiter`.
+
     Parameters
     ----------
     csv_path : Path
@@ -83,11 +160,12 @@ def check_csv_rows(csv_path: Path, min_rows: int = 2) -> dict:
         status : str — 'valid', 'insufficient', or 'error'
         error : str or None
     """
+    delimiter = detect_csv_delimiter(csv_path)
     try:
         for encoding in ('utf-8', 'latin-1'):
             try:
                 with open(csv_path, 'r', encoding=encoding) as f:
-                    row_count = sum(1 for _ in csv.reader(f))
+                    row_count = sum(1 for _ in csv.reader(f, delimiter=delimiter))
                 break
             except UnicodeDecodeError:
                 continue

--- a/util/raw_bucket_prep/validate_raw_bucket_structure.py
+++ b/util/raw_bucket_prep/validate_raw_bucket_structure.py
@@ -46,6 +46,7 @@ from pathlib import Path
 from datetime import datetime
 from collections import defaultdict
 import argparse
+import pandas as pd
 
 repo_root = Path(__file__).resolve().parents[2]
 metadata_root = repo_root.parent / "asap-crn-cloud-dataset-metadata"
@@ -65,11 +66,11 @@ from bucket_validation_utils import (
     )
 from file_utils import (
     get_file_extension,
-    check_csv_rows
+    check_csv_rows,
+    detect_csv_delimiter,
     )
 
 # crn-utils
-from crn_utils.util import load_tables
 from crn_utils.update_schema import get_table_update_map
 
 # asap-crn-cloud-dataset-metadata
@@ -350,8 +351,16 @@ def check_mandatory_column_consistency(metadata_dir: Path, mandatory_cols: dict)
         if not present:
             continue
 
-        tables = load_tables(metadata_dir, list(present.values()))
-        name_to_df = {t: tables[stem] for t, stem in present.items()}
+        name_to_df = {}
+        for t, stem in present.items():
+            table_path = metadata_dir / f"{stem}.csv"
+            delim = detect_csv_delimiter(table_path)
+            for enc in ('utf-8', 'latin-1'):
+                try:
+                    name_to_df[t] = pd.read_csv(table_path, sep=delim, encoding=enc)
+                    break
+                except UnicodeDecodeError:
+                    continue
 
         col_found_in = {}
         col_missing_in = []
@@ -552,10 +561,11 @@ def check_three_way_consistency(
                 break
         if sample_csv_path:
             result['sample_csv_found'] = True
+            sample_delim = detect_csv_delimiter(sample_csv_path)
             for encoding in ('utf-8', 'latin-1'):
                 try:
                     with open(sample_csv_path, 'r', encoding=encoding) as fh:
-                        reader = csv.DictReader(fh)
+                        reader = csv.DictReader(fh, delimiter=sample_delim)
                         col = next(
                             (k for k in (reader.fieldnames or []) if k.lower().strip() == 'sample_id'),
                             None,
@@ -590,10 +600,11 @@ def check_three_way_consistency(
     data_by_sample = defaultdict(list)  # lower sample_id → [{'sample_id': str, 'file_name': str}]
     all_file_names = []
 
+    data_delim = detect_csv_delimiter(data_csv_path)
     for encoding in ('utf-8', 'latin-1'):
         try:
             with open(data_csv_path, 'r', encoding=encoding) as fh:
-                reader = csv.DictReader(fh)
+                reader = csv.DictReader(fh, delimiter=data_delim)
                 fieldnames = reader.fieldnames or []
                 sample_id_key = next(
                     (k for k in fieldnames if k.lower().strip() == 'sample_id'), None
@@ -1250,6 +1261,12 @@ def get_important_warnings(result: dict) -> list[str]:
                 parts.append(f"{n_found_in_extra} found in {_folder_label}")
             warnings.append("Sample / Data / Bucket inconsistencies — " + ", ".join(parts))
 
+    # Non-comma delimiters in metadata files
+    non_comma = result.get('non_comma_delimiter_files', [])
+    if non_comma:
+        names = ', '.join(non_comma)
+        warnings.append(f"Non-comma delimiter in metadata file(s): {names}")
+
     # Unexpected folders
     unexpected = result.get('unexpected_folders', {})
     if unexpected:
@@ -1533,6 +1550,18 @@ def perform_bucket_validation(gs_bucket: str,
                         print(f"    Warning: Could not download metadata: {e2.stderr}")
                 else:
                     print(f"    Warning: Could not download metadata: {e.stderr}")
+            non_comma_files = []
+            if metadata_dir and metadata_dir.exists():
+                for csv_file in sorted(
+                    f for f in (list(metadata_dir.glob('*.csv')) + list(metadata_dir.glob('*.CSV')))
+                    if f.is_file() and not f.name.startswith('._')
+                ):
+                    delim = detect_csv_delimiter(csv_file)
+                    if delim != ',':
+                        non_comma_files.append(csv_file.name)
+            if non_comma_files:
+                results['non_comma_delimiter_files'] = non_comma_files
+
             metadata_results = analyze_metadata(metadata_dir, MIN_CSV_ROWS)
             results['metadata'] = metadata_results
             results['metadata_renames'] = metadata_renames
@@ -1747,6 +1776,9 @@ def generate_report(all_results: list, report_path: Path) -> None:
                     content_parts.append(f"{emoji_warning} {len(renames)} renamed")
                 if csv_issues:
                     content_parts.append(f"{emoji_warning} {len(csv_issues)} CSV issue(s)")
+                non_comma = result.get('non_comma_delimiter_files', [])
+                if non_comma:
+                    content_parts.append(f"{emoji_warning} {len(non_comma)} non-comma delimiter(s)")
                 content_status = " · ".join(content_parts) if content_parts else emoji_success
             else:
                 folder_status = _folder_not_found_status('metadata', set(MANDATORY_FOLDERS))

--- a/util/raw_bucket_prep/validate_raw_bucket_structure.py
+++ b/util/raw_bucket_prep/validate_raw_bucket_structure.py
@@ -127,10 +127,6 @@ _READ_ILLUMINA_SUFFIX_RE = re.compile(r'_[ri]\d+\.fastq\.gz$')
 # Ordered longest-first so '.fastq.gz' is matched before '.gz'.
 _FASTQ_EXTENSIONS = ('.fastq.gz', '.fq.gz', '.fastq', '.fq')
 
-# Suffixes stripped from metadata filenames after download so downstream code
-# always sees canonical table names (e.g. ASSAY_complete.csv → ASSAY.csv).
-_METADATA_FILE_SUFFIX_STRIP = ['_complete', '.cde_compared']
-
 emoji_success = "✅"
 emoji_error = "❌"
 emoji_warning = "⚠️"
@@ -139,11 +135,13 @@ emoji_warning = "⚠️"
 
 def strip_metadata_suffixes(metadata_dir: Path) -> list:
     """
-    Rename metadata files by stripping known non-standard suffixes.
+    Rename metadata files whose stem starts with a known table name.
 
-    Strips entries in `_METADATA_FILE_SUFFIX_STRIP` from filenames immediately
-    before the `.csv` extension (e.g. `ASSAY_complete.csv` → `ASSAY.csv`).
-    Skips macOS artefact files beginning with '._'.
+    Matches `<KNOWN_TABLE>_<anything>.csv` and `<KNOWN_TABLE>.<anything>.csv`,
+    renaming to `<KNOWN_TABLE>.csv`. The longest matching known stem wins.
+    Files already named canonically (stem in `_KNOWN_TABLE_STEMS`) are skipped,
+    as are macOS artefact files beginning with '._'.
+
     Prints a warning for each rename or skip.
 
     Parameters
@@ -160,33 +158,40 @@ def strip_metadata_suffixes(metadata_dir: Path) -> list:
     renames = []
     if not metadata_dir or not metadata_dir.exists():
         return renames
+
     for filepath in sorted(metadata_dir.iterdir()):
-        if not filepath.is_file():
+        if not filepath.is_file() or filepath.suffix.lower() != '.csv':
             continue
         if filepath.name.startswith('._'):
             continue
-        name = filepath.name
-        for suffix in _METADATA_FILE_SUFFIX_STRIP:
-            new_name = None
-            if name.lower().endswith(suffix.lower() + '.csv'):
-                new_name = name[:-(len(suffix) + 4)] + '.csv'
-            if new_name:
-                dest = filepath.parent / new_name
-                if dest.exists():
-                    renames.append({
-                        'original': name, 'renamed': new_name,
-                        'suffix': suffix, 'skipped': True,
-                        'reason': 'destination already exists',
-                    })
-                    print(f"    Warning: could not rename '{name}' → '{new_name}': destination already exists")
-                else:
-                    filepath.rename(dest)
-                    renames.append({
-                        'original': name, 'renamed': new_name,
-                        'suffix': suffix, 'skipped': False,
-                    })
-                    print(f"    Warning: renamed '{name}' → '{new_name}' (stripped suffix '{suffix}')")
-                break
+        stem_upper = filepath.stem.upper()
+        if stem_upper in _KNOWN_TABLE_STEMS:
+            continue
+        candidates = [
+            s for s in _KNOWN_TABLE_STEMS
+            if stem_upper.startswith(s + '_') or stem_upper.startswith(s + '.')
+        ]
+        if not candidates:
+            continue
+        matched_stem = max(candidates, key=len)
+        new_name = matched_stem + '.csv'
+        dest = filepath.parent / new_name
+        stripped_suffix = filepath.stem[len(matched_stem):]
+        if dest.exists():
+            renames.append({
+                'original': filepath.name, 'renamed': new_name,
+                'suffix': stripped_suffix, 'skipped': True,
+                'reason': 'destination already exists',
+            })
+            print(f"    Warning: could not rename '{filepath.name}' → '{new_name}': destination already exists")
+        else:
+            filepath.rename(dest)
+            renames.append({
+                'original': filepath.name, 'renamed': new_name,
+                'suffix': stripped_suffix, 'skipped': False,
+            })
+            print(f"    Warning: renamed '{filepath.name}' → '{new_name}' (stripped suffix '{stripped_suffix}')")
+
     return renames
 
 

--- a/util/raw_bucket_prep/validate_raw_bucket_structure.py
+++ b/util/raw_bucket_prep/validate_raw_bucket_structure.py
@@ -24,8 +24,7 @@ A bucket_validation.md report, including:
 Inconsistency reconciliation tables (if issues are found):
   - sample_id_issues.tsv
   - subject_id_issues.tsv
-  - data_vs_bucket.tsv
-  - sample_id_vs_file_name.tsv
+  - data_inconsistencies.tsv
 
 Usage as CLI:
 python3 validate_raw_bucket_structure.py -d team-smith-sc-rnaseq
@@ -355,7 +354,7 @@ def check_mandatory_column_consistency(metadata_dir: Path, mandatory_cols: dict)
         for t, stem in present.items():
             table_path = metadata_dir / f"{stem}.csv"
             delim = detect_csv_delimiter(table_path)
-            for enc in ('utf-8', 'latin-1'):
+            for enc in ('utf-8-sig', 'utf-8', 'latin-1'):
                 try:
                     name_to_df[t] = pd.read_csv(table_path, sep=delim, encoding=enc)
                     break
@@ -542,6 +541,7 @@ def check_three_way_consistency(
         'n_found_in_extra': 0,
         'found_in_extra_folders': {},
         'n_missing_bucket': 0,
+        'n_file_name_is_path': 0,
         'n_in_sample_only': 0,
         'n_in_data_only': 0,
         'n_sample_data_fuzzy': 0,
@@ -562,7 +562,7 @@ def check_three_way_consistency(
         if sample_csv_path:
             result['sample_csv_found'] = True
             sample_delim = detect_csv_delimiter(sample_csv_path)
-            for encoding in ('utf-8', 'latin-1'):
+            for encoding in ('utf-8-sig', 'utf-8', 'latin-1'):
                 try:
                     with open(sample_csv_path, 'r', encoding=encoding) as fh:
                         reader = csv.DictReader(fh, delimiter=sample_delim)
@@ -601,7 +601,7 @@ def check_three_way_consistency(
     all_file_names = []
 
     data_delim = detect_csv_delimiter(data_csv_path)
-    for encoding in ('utf-8', 'latin-1'):
+    for encoding in ('utf-8-sig', 'utf-8', 'latin-1'):
         try:
             with open(data_csv_path, 'r', encoding=encoding) as fh:
                 reader = csv.DictReader(fh, delimiter=data_delim)
@@ -624,9 +624,14 @@ def check_three_way_consistency(
                     return result
                 for row in reader:
                     sid = row[sample_id_key].strip()
-                    fn = row[file_name_key].strip()
+                    fn_raw = row[file_name_key].strip()
+                    fn = os.path.basename(fn_raw)
                     if sid and fn:
-                        data_by_sample[sid.lower()].append({'sample_id': sid, 'file_name': fn})
+                        data_by_sample[sid.lower()].append({
+                            'sample_id': sid,
+                            'file_name': fn,
+                            'file_name_was_path': fn != fn_raw,
+                        })
                         all_file_names.append(fn)
             break
         except UnicodeDecodeError:
@@ -826,13 +831,16 @@ def check_three_way_consistency(
     def _make_file_row(sample_id_sample, sample_id_data, entry):
         match = file_match_map.get(entry['file_name'], {'type': 'missing_in_bucket', 'bucket_files': []})
         bucket_file = ', '.join(match['bucket_files']) if match['bucket_files'] else '—'
-        return {
+        row = {
             'sample_id_sample': sample_id_sample,
             'sample_id_data': sample_id_data,
             'file_name': entry['file_name'],
             'bucket_file': bucket_file,
             'match_type': match['type'],
         }
+        if entry.get('file_name_was_path'):
+            row['file_name_was_path'] = True
+        return row
 
     for key in sorted(in_both):
         for entry in data_by_sample[key]:
@@ -895,6 +903,8 @@ def check_three_way_consistency(
         elif mt == 'missing_in_bucket':
             result['n_missing_bucket'] += 1
 
+    result['n_file_name_is_path'] = sum(1 for r in rows if r.get('file_name_was_path'))
+
     # ── 7. Issues ─────────────────────────────────────────────────────
     if result['n_missing_bucket']:
         result['issues'].append(
@@ -932,7 +942,10 @@ def write_data_inconsistencies_tsv(result: dict, tsv_path: Path) -> Path | None:
     Path
         Path to the written TSV, or None if there were no rows.
     """
-    rows = [r for r in result.get('rows', []) if r.get('match_type') != 'exact']
+    rows = [
+        r for r in result.get('rows', [])
+        if r.get('match_type') != 'exact' or r.get('file_name_was_path')
+    ]
     if not rows:
         return None
     with open(tsv_path, 'w', newline='', encoding='utf-8') as fh:
@@ -942,12 +955,15 @@ def write_data_inconsistencies_tsv(result: dict, tsv_path: Path) -> Path | None:
             'Bucket file(s)', 'Match type',
         ])
         for row in rows:
+            match_type = row['match_type']
+            if row.get('file_name_was_path'):
+                match_type += '. Match was found in a nested path'
             writer.writerow([
                 row['sample_id_sample'],
                 row['sample_id_data'],
                 row['file_name'],
                 row['bucket_file'],
-                row['match_type'],
+                match_type,
             ])
     return tsv_path
 
@@ -984,6 +1000,7 @@ def render_three_way_report(outfile, result: dict, raw_label: str, data_csv_name
     n_data_only = result.get('n_in_data_only', 0)
     n_sample_fuzzy = result.get('n_sample_data_fuzzy', 0)
     n_only_bucket = result.get('n_only_bucket', 0)
+    n_file_name_is_path = result.get('n_file_name_is_path', 0)
     md5_files = result.get('md5_files', [])
     tsv_path = result.get('tsv_path')
     use_sample = result.get('sample_csv_found') and result.get('sample_id_col_found')
@@ -991,6 +1008,8 @@ def render_three_way_report(outfile, result: dict, raw_label: str, data_csv_name
     summary_parts = []
     if n_exact:
         summary_parts.append(f"{emoji_success} **{n_exact} exact**")
+    if n_file_name_is_path:
+        summary_parts.append(f"{emoji_warning} **{n_file_name_is_path} nested paths** (not at root of raw folder)")
     if n_partial:
         summary_parts.append(f"{emoji_warning} **{n_partial} partial** (Illumina suffix — need renaming)")
     if n_fuzzy:
@@ -1011,7 +1030,7 @@ def render_three_way_report(outfile, result: dict, raw_label: str, data_csv_name
     if n_only_bucket:
         summary_parts.append(f"{emoji_error} **{n_only_bucket} only in bucket**")
 
-    has_issues = any([n_partial, n_fuzzy, n_sample_fuzzy, n_prefix, n_extra, n_missing, n_sample_only, n_data_only, n_only_bucket])
+    has_issues = any([n_partial, n_fuzzy, n_sample_fuzzy, n_prefix, n_extra, n_missing, n_sample_only, n_data_only, n_only_bucket, n_file_name_is_path])
     summary = " · ".join(summary_parts)
     if md5_files:
         summary += f" · *{len(md5_files)} .md5 file(s) excluded*"
@@ -1077,19 +1096,23 @@ def render_three_way_report(outfile, result: dict, raw_label: str, data_csv_name
     def _note(row):
         mt = row['match_type']
         if mt == 'in_sample_only':
-            return 'Not in DATA'
-        if mt == 'in_data_only':
-            return 'Not in SAMPLE'
-        if mt == 'sample_id_fuzzy':
-            return 'Fuzzy match — sample_id separator/case'
-        if mt == 'only_in_bucket':
-            return 'Only in bucket'
-        if mt == 'missing_in_bucket':
-            return 'Missing in bucket'
-        if mt.startswith('found_in_'):
+            note = 'Not in DATA'
+        elif mt == 'in_data_only':
+            note = 'Not in SAMPLE'
+        elif mt == 'sample_id_fuzzy':
+            note = 'Fuzzy match — sample_id separator/case'
+        elif mt == 'only_in_bucket':
+            note = 'Only in bucket'
+        elif mt == 'missing_in_bucket':
+            note = 'Missing in bucket'
+        elif mt.startswith('found_in_'):
             folder = mt[len('found_in_'):]
-            return f'Found in {folder}/'
-        return mt.replace('_', ' ')
+            note = f'Found in {folder}/'
+        else:
+            note = mt.replace('_', ' ')
+        if row.get('file_name_was_path'):
+            note += ' · file_name is a nested path'
+        return note
 
     wrote_table_header = False
     for cat_key, cat_label in _DISPLAY_ORDER:
@@ -1260,6 +1283,13 @@ def get_important_warnings(result: dict) -> list[str]:
                 _folder_label = ", ".join(f"{f}/" for f in sorted(extra_folders)) if extra_folders else "extra folder"
                 parts.append(f"{n_found_in_extra} found in {_folder_label}")
             warnings.append("Sample / Data / Bucket inconsistencies — " + ", ".join(parts))
+
+    # Files referenced by nested path in DATA.csv (nested subdirectories)
+    n_file_name_is_path = three_way.get('n_file_name_is_path', 0)
+    if n_file_name_is_path:
+        warnings.append(
+            f"DATA.csv file_name: {n_file_name_is_path} file(s) use nested paths, not at root of raw folder"
+        )
 
     # Non-comma delimiters in metadata files
     non_comma = result.get('non_comma_delimiter_files', [])


### PR DESCRIPTION
## Description
Adds alternative delimiter auto-detection to `validate_raw_bucket_structure.py` and its dependencies, so metadata files using semicolons, tabs, or pipes are read correctly without any manual flag.

Key changes:
- Add `detect_csv_delimiter()` to `file_utils.py`, adapted from crn-meta-validate, no Streamlit dependency.
- Apply auto-detected delimiter + `utf-8-sig` to handle Byte Order Mark (BOM) when reading `SAMPLE.csv` and `DATA.csv`. This is needed to parse tables with BOM — a hidden Unicode character (`\ufeff`) that some applications (notably Excel) prepend to UTF-8 files and malform Pandas data frame formation.
- Strip `DATA.csv` `file_name` values to basename so full GCS paths (nested subdirectories like `fastqs/bla/bla/file_fastq.gz`) still match `file_fastq.gz` bucket files. Warnings are recorded in `bucket_validation.md` Executive Summary and `data_inconsistencies.tsv`.
- Extend normalization of metadata filenames, to handle cases like: `TABLE_<anything>.csv`, like: `TABLE_<dataset_name>.csv`, `TABLE_complete.csv`, `TABLE.cde_compared.csv`).

Other changes:
- Add documentation of requirements
  - `pyproject.toml`: declare `requires-python >=3.10`
  - `README.md`: document Python version requirement

Tested with:
New:    
`python3 util/raw_bucket_prep/validate_raw_bucket_structure.py -d team-voet-human-colon-sn-rnaseq`    
and previously tester runs:     
`for i in team-liddle-human-fecal-metagenome team-edwards-mouse-spatial-visium-chchd2 team-gradinaru-fecal-metagenome-aso-fmt team-scherzer-pmdbs-sn-multiome-midbrain ; do python3 ~/asap_repos/wf-common/util/raw_bucket_prep/validate_raw_bucket_structure.py -d $i; done`

## Dependencies (Issues/PRs)
[ClickUp Issue](https://app.clickup.com/t/9014209604/BIOS-1787)

## Type of Change
- [x] Bug fix
- [x] New feature
- [x] Documentation

## Task Checklist
- [x] Documentation updated
- [x] Human reviewed any code produced or modified by AI